### PR TITLE
Fix ActionView::Template::Error (undefined method `resource_index_route_key'

### DIFF
--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -8,12 +8,13 @@ as defined by the routes in the `admin/` namespace
 %>
 
 <nav class="navigation" role="navigation">
-  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+  <%= link_to(t("administrate.navigation.back_to_app"), root_url, class: "button button--alt") if defined?(root_url) %>
+
+  <% Administrate::Namespace.new(namespace).resources_with_index_route.each do |resource| %>
     <%= link_to(
       display_resource_name(resource),
-      [namespace, resource_index_route_key(resource)],
+      resource_index_route(resource),
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
-    ) if valid_action? :index, resource  %>
+    ) if valid_action?(:index, resource) && show_action?(:index, model_from_resource(resource)) %>
   <% end %>
-  <%= link_to("sidekiq", sidekiq_web_url) %>
 </nav>


### PR DESCRIPTION
- administrateが0.14で、`resource_index_route_key`が削除されたため以下のエラーが発生した。
   - `bin/rails g administrate:views:navigation`でnavigationを再生成して対応

```
ActionView::Template::Error (undefined method `resource_index_route_key' for #<#<Class:0x00007f9fd62ecd40>:0x00007f9fd62e6e18>
Did you mean?  resource_index_route):
    11:   <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
    12:     <%= link_to(
    13:       display_resource_name(resource),
    14:       [namespace, resource_index_route_key(resource)],
    15:       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
    16:     ) if valid_action? :index, resource  %>
    17:   <% end %>
```