### PR TITLE
Dockerfileを更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ruby:3.2.2-bullseye
+FROM ruby:3.2.2-bookworm
 
 WORKDIR /app
 
-# Using Node.js v18.x(LTS)
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+# Using Node.js v20.x(LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 
 # Postgresql 14
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 RUN apt install curl ca-certificates gnupg
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 


### PR DESCRIPTION
- bookworm(Ubuntu 22.04)にアップデート
- nodeを20にアップデート
- postgresqlのlsb_releaseを直接指定するように変更