### PR TITLE
fix: with_retryメソッドのキーワード引数エラーを修正

### DIFF
--- a/app/services/scrapers/base_scraper.rb
+++ b/app/services/scrapers/base_scraper.rb
@@ -14,7 +14,7 @@ module Scrapers
 
     attr_reader :browser_manager
 
-    def with_retry(retries: 3, retry_logger: Rails.logger, &)
+    def with_retry(max_retries: 3, errors: RETRYABLE_ERRORS, on_retry: nil, &)
       super
     end
 


### PR DESCRIPTION
## Summary
- BaseScraperクラスのwith_retryメソッドのシグネチャを修正し、親モジュールRetryableとの互換性を保つ

## Changes
- `retries:` パラメータを `max_retries:` に変更
- `errors:` と `on_retry:` パラメータを追加
- `retry_logger:` パラメータを削除

## Test plan
- [ ] with_retryメソッドが正常に動作することを確認
- [ ] リトライ機能が期待通りに動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)