### PR TITLE
fix: BaseScraper に reset_browser_manager メソッドを追加

### DIFF
--- a/app/services/scrapers/base_scraper.rb
+++ b/app/services/scrapers/base_scraper.rb
@@ -18,6 +18,10 @@ module Scrapers
       super
     end
 
+    def reset_browser_manager(timeout: 10, process_timeout: 10)
+      @browser_manager = BrowserManager.new(timeout:, process_timeout:)
+    end
+
     def save_song(song_attrs)
       display_artist = ensure_display_artist(song_attrs[:artist_name], song_attrs[:artist_url])
 


### PR DESCRIPTION
## Summary
- `Scrapers::DamScraper` と `Scrapers::JoysoundScraper` で呼び出されていた `reset_browser_manager` メソッドが `BaseScraper` に実装されていなかったため、`NoMethodError` が発生していた問題を修正
- `BaseScraper` クラスに `reset_browser_manager` メソッドを追加し、新しい `BrowserManager` インスタンスを作成するように実装

## Test plan
- [x] `make minitest` でテストが正常に実行されることを確認
- [ ] DAM楽曲の配信機種情報更新処理でエラーが発生しないことを確認
- [ ] JOYSOUND楽曲の取得処理でエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)