### PR TITLE
楽曲-配信機種関連付けの重複防止機能を実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,9 +35,16 @@ Rails/UnknownEnv:
 Rails/EnvironmentVariableAccess:
   AllowReads: true
 
+# 運用スクリプトではexit使用を許可
+Rails/Exit:
+  Exclude:
+    - lib/**/*
+
+# 運用スクリプトではupdate_all使用を許可
 Rails/SkipsModelValidations:
   Exclude:
     - db/seeds/*
+    - lib/**/*
 
 Style/SignalException:
   Exclude:

--- a/app/models/songs_karaoke_delivery_model.rb
+++ b/app/models/songs_karaoke_delivery_model.rb
@@ -1,4 +1,22 @@
 class SongsKaraokeDeliveryModel < ApplicationRecord
   belongs_to :song
   belongs_to :karaoke_delivery_model
+
+  # 同じ楽曲に同じ配信機種が重複して紐づくことを防ぐ
+  validates :song_id, uniqueness: { scope: :karaoke_delivery_model_id }
+
+  # 重複チェック付きの安全な作成メソッド
+  def self.find_or_create_association(song_id, karaoke_delivery_model_id)
+    find_or_create_by(song_id:, karaoke_delivery_model_id:)
+  rescue ActiveRecord::RecordNotUnique
+    # 他のプロセスが同時に作成した場合
+    find_by!(song_id:, karaoke_delivery_model_id:)
+  end
+
+  # バッチでの安全な作成
+  def self.create_associations_safely(song_id, karaoke_delivery_model_ids)
+    karaoke_delivery_model_ids.filter_map do |delivery_model_id|
+      find_or_create_association(song_id, delivery_model_id)
+    end
+  end
 end

--- a/app/services/delivery_model_validator.rb
+++ b/app/services/delivery_model_validator.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# 配信機種の作成・更新時のバリデーションを強化するサービスクラス
+#
+# 機能:
+#   1. 配信機種名の正規化（空白の除去、全角/半角統一など）
+#   2. 重複チェックの強化
+#   3. 作成前の事前検証
+#
+# 使用例:
+#   validator = DeliveryModelValidator.new
+#
+#   # 正規化
+#   normalized_name = validator.normalize_name("　JOYSOUND MAX GO　")
+#   # => "JOYSOUND MAX GO"
+#
+#   # 重複チェック
+#   if validator.duplicate_exists?("JOYSOUND MAX GO", "JOYSOUND")
+#     puts "重複があります"
+#   end
+#
+#   # 安全な作成
+#   model = validator.find_or_create_safely("JOYSOUND MAX GO", "JOYSOUND")
+class DeliveryModelValidator
+  # 配信機種名を正規化
+  def normalize_name(name)
+    return nil if name.blank?
+
+    normalized = name.to_s.strip
+
+    # 全角スペースを半角スペースに変換
+    normalized = normalized.tr('　', ' ')
+
+    # 連続する空白を単一の空白に変換
+    normalized = normalized.gsub(/\s+/, ' ')
+
+    # 前後の空白を除去
+    normalized.strip
+  end
+
+  # 重複チェック（正規化も含む）
+  def duplicate_exists?(name, karaoke_type)
+    normalized_name = normalize_name(name)
+    return false if normalized_name.blank?
+
+    KaraokeDeliveryModel.exists?(name: normalized_name, karaoke_type:)
+  end
+
+  # 安全な作成（重複チェック + 正規化）
+  def find_or_create_safely(name, karaoke_type)
+    normalized_name = normalize_name(name)
+
+    if normalized_name.blank?
+      Rails.logger.warn("DeliveryModelValidator: Invalid name provided: #{name.inspect}")
+      return nil
+    end
+
+    # 既存レコードを検索
+    existing_model = KaraokeDeliveryModel.find_by(name: normalized_name, karaoke_type:)
+    return existing_model if existing_model
+
+    # 作成前の最終チェック
+    if duplicate_exists?(normalized_name, karaoke_type)
+      Rails.logger.info("DeliveryModelValidator: Duplicate detected during creation: #{normalized_name} (#{karaoke_type})")
+      return KaraokeDeliveryModel.find_by(name: normalized_name, karaoke_type:)
+    end
+
+    # 新規作成
+    begin
+      model = KaraokeDeliveryModel.create!(name: normalized_name, karaoke_type:)
+      Rails.logger.info("DeliveryModelValidator: Created new model: #{normalized_name} (#{karaoke_type})")
+      model
+    rescue ActiveRecord::RecordNotUnique => e
+      Rails.logger.warn("DeliveryModelValidator: Race condition detected: #{e.message}")
+      # 他のプロセスが同時に作成した場合
+      KaraokeDeliveryModel.find_by!(name: normalized_name, karaoke_type:)
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error("DeliveryModelValidator: Validation failed: #{e.message}")
+      nil
+    end
+  end
+
+  # バッチでの安全な作成
+  def find_or_create_safely_batch(names, karaoke_type)
+    names.filter_map { |name| find_or_create_safely(name, karaoke_type) }
+  end
+
+  # 既存レコードの正規化（データクリーンアップ用）
+  def normalize_existing_records
+    updated_count = 0
+
+    KaraokeDeliveryModel.find_each do |model|
+      normalized_name = normalize_name(model.name)
+
+      next if normalized_name == model.name
+
+      # 正規化後の名前で重複がないかチェック
+      if KaraokeDeliveryModel.where(name: normalized_name, karaoke_type: model.karaoke_type)
+                             .where.not(id: model.id)
+                             .exists?
+        Rails.logger.warn("DeliveryModelValidator: Cannot normalize #{model.name} → #{normalized_name} (duplicate would be created)")
+        next
+      end
+
+      begin
+        model.update!(name: normalized_name)
+        updated_count += 1
+        Rails.logger.info("DeliveryModelValidator: Normalized #{model.name} → #{normalized_name}")
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error("DeliveryModelValidator: Failed to normalize #{model.name}: #{e.message}")
+      end
+    end
+
+    Rails.logger.info("DeliveryModelValidator: Normalized #{updated_count} records")
+    updated_count
+  end
+end

--- a/db/migrate/20250615030553_add_unique_constraint_to_songs_karaoke_delivery_models.rb
+++ b/db/migrate/20250615030553_add_unique_constraint_to_songs_karaoke_delivery_models.rb
@@ -1,0 +1,10 @@
+class AddUniqueConstraintToSongsKaraokeDeliveryModels < ActiveRecord::Migration[7.1]
+  def change
+    # song_id + karaoke_delivery_model_idの組み合わせにユニーク制約を追加
+    # 同じ楽曲に同じ配信機種が重複して紐づくことを防ぐ
+    add_index :songs_karaoke_delivery_models,
+              %i[song_id karaoke_delivery_model_id],
+              unique: true,
+              name: 'index_songs_delivery_models_on_song_and_delivery_model'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_01_092300) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_15_030553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_01_092300) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["karaoke_delivery_model_id"], name: "idx_songs_karaoke_delivery_models_on_karaoke_delivery_model_id"
+    t.index ["song_id", "karaoke_delivery_model_id"], name: "index_songs_delivery_models_on_song_and_delivery_model", unique: true
     t.index ["song_id"], name: "index_songs_karaoke_delivery_models_on_song_id"
   end
 

--- a/lib/add_unique_constraint_to_song_delivery_models.rb
+++ b/lib/add_unique_constraint_to_song_delivery_models.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# 楽曲-配信機種関連付けにユニーク制約を追加するスクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/add_unique_constraint_to_song_delivery_models.rb
+#
+# 処理内容:
+#   1. 重複データのチェック
+#   2. 重複がある場合は事前修正を促す
+#   3. 重複がない場合はマイグレーション実行
+#   4. ユニーク制約の追加
+#
+# 注意事項:
+#   - 重複データがある場合はマイグレーションが失敗します
+#   - 事前にfix_song_delivery_model_duplicates.rbを実行してください
+
+require 'English'
+puts "楽曲-配信機種関連付けへのユニーク制約追加を開始します..."
+
+# 1. 重複チェック
+puts "🔍 重複データをチェック中..."
+
+duplicate_groups = SongsKaraokeDeliveryModel
+                   .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
+                   .group('song_id, karaoke_delivery_model_id')
+                   .having('COUNT(*) > 1')
+
+if duplicate_groups.any?
+  puts "❌ #{duplicate_groups.count}組の重複が見つかりました。"
+  puts "   ユニーク制約を追加する前に重複を解決する必要があります。"
+  puts ""
+  puts "🔧 重複解決手順:"
+  puts "  1. 重複を確認: docker compose run --rm web bin/rails r lib/check_song_delivery_model_duplicates.rb"
+  puts "  2. 重複を修正: docker compose run --rm web bin/rails r lib/fix_song_delivery_model_duplicates.rb"
+  puts "  3. このスクリプトを再実行"
+  exit 1
+end
+
+puts "✅ 重複は見つかりませんでした。"
+
+# 2. マイグレーション実行
+puts "\n🔧 ユニーク制約を追加中..."
+
+begin
+  # マイグレーション実行
+  system("docker compose run --rm web bin/rails db:migrate")
+
+  if $CHILD_STATUS.success?
+    puts "✅ ユニーク制約の追加が完了しました！"
+
+    # 3. 制約が正しく追加されたか確認
+    puts "\n🔍 制約の確認中..."
+
+    # データベースから制約を確認
+    result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
+      SELECT indexname, indexdef#{' '}
+      FROM pg_indexes#{' '}
+      WHERE tablename = 'songs_karaoke_delivery_models'#{' '}
+      AND indexdef LIKE '%UNIQUE%'
+    SQL
+
+    if result.any?
+      puts "✅ ユニーク制約が正常に追加されました:"
+      result.each do |row|
+        puts "  - #{row['indexname']}: #{row['indexdef']}"
+      end
+    else
+      puts "⚠️  ユニーク制約の確認に失敗しました。手動で確認してください。"
+    end
+
+    puts "\n📊 現在の統計:"
+    total_associations = SongsKaraokeDeliveryModel.count
+    unique_associations = SongsKaraokeDeliveryModel.select('DISTINCT song_id, karaoke_delivery_model_id').count
+
+    puts "  総関連付けレコード数: #{total_associations}件"
+    puts "  ユニークな関連付け数: #{unique_associations}件"
+
+    if total_associations == unique_associations
+      puts "  ✅ すべての関連付けがユニークです"
+    else
+      puts "  ⚠️  不整合があります (#{total_associations - unique_associations}件の重複)"
+    end
+
+  else
+    puts "❌ マイグレーションが失敗しました。"
+    puts "   エラーの詳細はログを確認してください。"
+    exit 1
+  end
+rescue StandardError => e
+  puts "❌ エラーが発生しました: #{e.message}"
+  exit 1
+end
+
+puts "\n🎉 作業完了！"
+puts "\n💡 今後の使用方法:"
+puts "  楽曲と配信機種の関連付けを作成する際は、以下のメソッドを使用してください:"
+puts "  SongsKaraokeDeliveryModel.find_or_create_association(song_id, delivery_model_id)"
+puts "  SongsKaraokeDeliveryModel.create_associations_safely(song_id, delivery_model_ids)"

--- a/lib/add_unique_constraint_to_song_delivery_models.rb
+++ b/lib/add_unique_constraint_to_song_delivery_models.rb
@@ -22,9 +22,9 @@ puts "楽曲-配信機種関連付けへのユニーク制約追加を開始し�
 puts "🔍 重複データをチェック中..."
 
 duplicate_groups = SongsKaraokeDeliveryModel
-                   .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
                    .group(:song_id, :karaoke_delivery_model_id)
                    .having('COUNT(*) > 1')
+                   .select(:song_id, :karaoke_delivery_model_id)
 
 if duplicate_groups.any?
   puts "❌ #{duplicate_groups.count}組の重複が見つかりました。"

--- a/lib/add_unique_constraint_to_song_delivery_models.rb
+++ b/lib/add_unique_constraint_to_song_delivery_models.rb
@@ -23,7 +23,7 @@ puts "🔍 重複データをチェック中..."
 
 duplicate_groups = SongsKaraokeDeliveryModel
                    .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
-                   .group('song_id, karaoke_delivery_model_id')
+                   .group(:song_id, :karaoke_delivery_model_id)
                    .having('COUNT(*) > 1')
 
 if duplicate_groups.any?

--- a/lib/check_delivery_model_duplicates.rb
+++ b/lib/check_delivery_model_duplicates.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# JOYSOUNDの配信機種に重複がないかチェックするスクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/check_delivery_model_duplicates.rb
+#
+# 機能:
+#   1. name + karaoke_typeの組み合わせで重複をチェック
+#   2. 重複がある場合は詳細を表示
+#   3. 重複の解決方法を提案
+#
+# 出力例:
+#   重複が見つかりました: JOYSOUND MAX GO (JOYSOUND) - 2件
+#   ID: uuid1, Order: 1, Created: 2024-01-01
+#   ID: uuid2, Order: 2, Created: 2024-01-02
+
+puts "配信機種の重複チェックを開始します..."
+
+# 全ての配信機種を取得
+all_models = KaraokeDeliveryModel.includes(:songs)
+
+# name + karaoke_typeでグループ化
+grouped_models = all_models.group_by { |model| [model.name, model.karaoke_type] }
+
+# 重複を検出
+duplicates = grouped_models.select { |_key, models| models.size > 1 }
+
+if duplicates.empty?
+  puts "✅ 重複は見つかりませんでした。"
+else
+  puts "❌ #{duplicates.size}組の重複が見つかりました:\n"
+
+  duplicates.each do |(name, karaoke_type), models|
+    puts "📋 #{name} (#{karaoke_type}) - #{models.size}件の重複"
+
+    models.sort_by(&:created_at).each_with_index do |model, index|
+      songs_count = model.songs.count
+      puts "  #{index + 1}. ID: #{model.id}"
+      puts "     Order: #{model.order}"
+      puts "     Created: #{model.created_at.strftime('%Y-%m-%d %H:%M:%S')}"
+      puts "     関連楽曲数: #{songs_count}件"
+    end
+
+    # 統合の提案
+    oldest_model = models.min_by(&:created_at)
+    newer_models = models - [oldest_model]
+    total_songs = models.sum { |model| model.songs.count }
+
+    puts "  💡 統合提案:"
+    puts "     保持: #{oldest_model.id} (最古, #{oldest_model.songs.count}楽曲)"
+    puts "     削除対象: #{newer_models.map(&:id).join(', ')}"
+    puts "     移行予定楽曲数: #{newer_models.sum { |model| model.songs.count }}件"
+    puts "     統合後楽曲数: #{total_songs}件"
+    puts ""
+  end
+
+  puts "🔧 修復方法:"
+  puts "  以下のコマンドを実行して重複を解決できます:"
+  puts "  docker compose run --rm web bin/rails r lib/fix_delivery_model_duplicates.rb"
+end
+
+puts "\n📊 統計情報:"
+puts "  総配信機種数: #{all_models.count}件"
+puts "  ユニークな組み合わせ数: #{grouped_models.size}件"
+puts "  JOYSOUND機種数: #{all_models.count { |m| m.karaoke_type == 'JOYSOUND' }}件"
+puts "  DAM機種数: #{all_models.count { |m| m.karaoke_type == 'DAM' }}件"
+
+puts "\n✅ チェック完了"

--- a/lib/check_song_delivery_model_duplicates.rb
+++ b/lib/check_song_delivery_model_duplicates.rb
@@ -22,9 +22,10 @@ puts "楽曲-配信機種関連付けの重複チェックを開始します..."
 puts "🔍 重複検出中..."
 
 duplicate_groups = SongsKaraokeDeliveryModel
-                   .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
                    .group(:song_id, :karaoke_delivery_model_id)
                    .having('COUNT(*) > 1')
+                   .select(:song_id, :karaoke_delivery_model_id)
+                   .includes(:song, :karaoke_delivery_model)
 
 if duplicate_groups.empty?
   puts "✅ 重複は見つかりませんでした。"
@@ -41,8 +42,8 @@ else
                         .includes(:song, :karaoke_delivery_model)
                         .order(:created_at)
 
-    song = duplicate_records.first.song
-    delivery_model = duplicate_records.first.karaoke_delivery_model
+    song = group.song
+    delivery_model = group.karaoke_delivery_model
 
     puts "📋 楽曲: \"#{song.title}\" (#{song.karaoke_type})"
     puts "   配信機種: \"#{delivery_model.name}\""

--- a/lib/check_song_delivery_model_duplicates.rb
+++ b/lib/check_song_delivery_model_duplicates.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# 楽曲と配信機種の関連付けで重複がないかチェックするスクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/check_song_delivery_model_duplicates.rb
+#
+# 機能:
+#   1. song_id + karaoke_delivery_model_idの組み合わせで重複をチェック
+#   2. 重複がある場合は詳細を表示（楽曲名、配信機種名、重複数）
+#   3. 重複解決の提案を表示
+#
+# 出力例:
+#   重複が見つかりました: [楽曲名] × [配信機種名] - 3件
+#   ID: uuid1, Created: 2024-01-01 10:00:00
+#   ID: uuid2, Created: 2024-01-01 10:01:00
+#   ID: uuid3, Created: 2024-01-01 10:02:00
+
+puts "楽曲-配信機種関連付けの重複チェックを開始します..."
+
+# song_id + karaoke_delivery_model_idでグループ化して重複を検出
+puts "🔍 重複検出中..."
+
+duplicate_groups = SongsKaraokeDeliveryModel
+                   .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
+                   .group('song_id, karaoke_delivery_model_id')
+                   .having('COUNT(*) > 1')
+
+if duplicate_groups.empty?
+  puts "✅ 重複は見つかりませんでした。"
+else
+  puts "❌ #{duplicate_groups.count}組の重複が見つかりました:\n"
+
+  total_duplicates = 0
+  total_redundant_records = 0
+
+  duplicate_groups.each do |group|
+    # 該当する全レコードを取得
+    duplicate_records = SongsKaraokeDeliveryModel
+                        .where(song_id: group.song_id, karaoke_delivery_model_id: group.karaoke_delivery_model_id)
+                        .includes(:song, :karaoke_delivery_model)
+                        .order(:created_at)
+
+    song = duplicate_records.first.song
+    delivery_model = duplicate_records.first.karaoke_delivery_model
+
+    puts "📋 楽曲: \"#{song.title}\" (#{song.karaoke_type})"
+    puts "   配信機種: \"#{delivery_model.name}\""
+    puts "   重複数: #{duplicate_records.count}件"
+
+    duplicate_records.each_with_index do |record, index|
+      marker = index.zero? ? "🟢 保持" : "🔴 削除候補"
+      puts "   #{marker} ID: #{record.id}, Created: #{record.created_at.strftime('%Y-%m-%d %H:%M:%S')}"
+    end
+
+    puts ""
+    total_duplicates += 1
+    total_redundant_records += (duplicate_records.count - 1)
+  end
+
+  puts "📊 重複統計:"
+  puts "  重複組数: #{total_duplicates}組"
+  puts "  削除可能レコード数: #{total_redundant_records}件"
+  puts "  削除後の総レコード数: #{SongsKaraokeDeliveryModel.count - total_redundant_records}件"
+
+  puts "\n🔧 修復方法:"
+  puts "  以下のコマンドを実行して重複を解決できます:"
+  puts "  docker compose run --rm web bin/rails r lib/fix_song_delivery_model_duplicates.rb"
+end
+
+puts "\n📈 全体統計:"
+total_associations = SongsKaraokeDeliveryModel.count
+unique_associations = SongsKaraokeDeliveryModel.select('DISTINCT song_id, karaoke_delivery_model_id').count
+total_songs = Song.count
+total_delivery_models = KaraokeDeliveryModel.count
+
+puts "  総関連付けレコード数: #{total_associations}件"
+puts "  ユニークな関連付け数: #{unique_associations}件"
+puts "  総楽曲数: #{total_songs}件"
+puts "  総配信機種数: #{total_delivery_models}件"
+puts "  平均関連付け数/楽曲: #{(total_associations.to_f / total_songs).round(2)}件" if total_songs.positive?
+
+puts "\n✅ チェック完了"

--- a/lib/check_song_delivery_model_duplicates.rb
+++ b/lib/check_song_delivery_model_duplicates.rb
@@ -23,7 +23,7 @@ puts "🔍 重複検出中..."
 
 duplicate_groups = SongsKaraokeDeliveryModel
                    .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
-                   .group('song_id, karaoke_delivery_model_id')
+                   .group(:song_id, :karaoke_delivery_model_id)
                    .having('COUNT(*) > 1')
 
 if duplicate_groups.empty?

--- a/lib/fix_delivery_model_duplicates.rb
+++ b/lib/fix_delivery_model_duplicates.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# JOYSOUNDの配信機種の重複を修正するスクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/fix_delivery_model_duplicates.rb
+#
+# 処理内容:
+#   1. 重複している配信機種を検出
+#   2. 最古のレコードを保持対象として選択
+#   3. 新しいレコードの関連楽曲を最古のレコードに移行
+#   4. 重複レコードを削除
+#   5. order値の再調整
+#
+# 安全性:
+#   - トランザクション内で実行
+#   - バックアップの確認を促す
+#   - 各ステップの詳細ログ出力
+
+puts "配信機種の重複修正を開始します..."
+puts "⚠️  この操作は不可逆です。事前にデータベースのバックアップを確認してください。"
+puts ""
+
+# 確認プロンプト
+print "続行しますか？ (yes/no): "
+confirmation = $stdin.gets.chomp.downcase
+unless confirmation == 'yes'
+  puts "処理をキャンセルしました。"
+  exit
+end
+
+# 統計情報を初期化
+stats = {
+  duplicates_found: 0,
+  records_merged: 0,
+  songs_migrated: 0,
+  records_deleted: 0,
+  errors: []
+}
+
+ActiveRecord::Base.transaction do
+  # 全ての配信機種を取得
+  all_models = KaraokeDeliveryModel.includes(:songs)
+
+  # name + karaoke_typeでグループ化
+  grouped_models = all_models.group_by { |model| [model.name, model.karaoke_type] }
+
+  # 重複を検出
+  duplicates = grouped_models.select { |_key, models| models.size > 1 }
+
+  if duplicates.empty?
+    puts "✅ 重複は見つかりませんでした。"
+  else
+    stats[:duplicates_found] = duplicates.size
+    puts "📋 #{duplicates.size}組の重複を修正します...\n"
+
+    duplicates.each do |(name, karaoke_type), models|
+      puts "🔧 修正中: #{name} (#{karaoke_type})"
+
+      # 最古のモデルを保持対象として選択
+      target_model = models.min_by(&:created_at)
+      duplicate_models = models - [target_model]
+
+      puts "  保持: #{target_model.id} (#{target_model.created_at.strftime('%Y-%m-%d')})"
+      puts "  削除対象: #{duplicate_models.size}件"
+
+      # 各重複モデルの楽曲を移行
+      duplicate_models.each do |duplicate_model|
+        songs_count = duplicate_model.songs.count
+
+        if songs_count.positive?
+          puts "    楽曲移行: #{duplicate_model.id} → #{target_model.id} (#{songs_count}件)"
+
+          # songs_karaoke_delivery_modelsテーブルのレコードを更新
+          SongsKaraokeDeliveryModel
+            .where(karaoke_delivery_model_id: duplicate_model.id)
+            .update_all(karaoke_delivery_model_id: target_model.id)
+
+          stats[:songs_migrated] += songs_count
+        end
+
+        # 重複モデルを削除
+        puts "    削除: #{duplicate_model.id}"
+        duplicate_model.destroy!
+        stats[:records_deleted] += 1
+      end
+
+      stats[:records_merged] += 1
+      puts "  ✅ 完了\n"
+    rescue StandardError => e
+      error_msg = "エラー: #{name} (#{karaoke_type}) - #{e.message}"
+      puts "  ❌ #{error_msg}"
+      stats[:errors] << error_msg
+      raise e # トランザクションをロールバック
+    end
+  end
+
+  # order値の再調整（acts_as_listが自動で行うが、念のため）
+  puts "📊 order値の再調整..."
+  %w[JOYSOUND DAM].each do |karaoke_type|
+    models = KaraokeDeliveryModel.where(karaoke_type:).order(:order)
+    models.each_with_index do |model, index|
+      new_order = index + 1
+      if model.order != new_order
+        model.update!(order: new_order)
+        puts "  #{model.name}: order #{model.order} → #{new_order}"
+      end
+    end
+  end
+
+  puts "\n📈 修正結果:"
+  puts "  重複組数: #{stats[:duplicates_found]}"
+  puts "  統合された機種: #{stats[:records_merged]}"
+  puts "  移行楽曲数: #{stats[:songs_migrated]}"
+  puts "  削除レコード数: #{stats[:records_deleted]}"
+
+  if stats[:errors].any?
+    puts "  エラー数: #{stats[:errors].size}"
+    stats[:errors].each { |error| puts "    - #{error}" }
+    raise "エラーが発生したため処理を中止します"
+  end
+
+  puts "\n✅ 修正完了！"
+
+  # DeliveryModelManagerのキャッシュをクリア
+  DeliveryModelManager.instance.clear_cache
+  puts "📦 DeliveryModelManagerのキャッシュをクリアしました"
+end
+
+puts "\n🔍 修正後の確認:"
+puts "  以下のコマンドで重複がないことを確認してください:"
+puts "  docker compose run --rm web bin/rails r lib/check_delivery_model_duplicates.rb"

--- a/lib/fix_song_delivery_model_duplicates.rb
+++ b/lib/fix_song_delivery_model_duplicates.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# 楽曲と配信機種の重複関連付けを修正するスクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/fix_song_delivery_model_duplicates.rb
+#
+# 処理内容:
+#   1. song_id + karaoke_delivery_model_idの重複組み合わせを検出
+#   2. 各重複グループで最古のレコードを保持
+#   3. その他の重複レコードを削除
+#   4. 削除前後の統計情報を表示
+#
+# 安全性:
+#   - トランザクション内で実行
+#   - バックアップの確認を促す
+#   - 各ステップの詳細ログ出力
+
+puts "楽曲-配信機種関連付けの重複修正を開始します..."
+puts "⚠️  この操作は不可逆です。事前にデータベースのバックアップを確認してください。"
+puts ""
+
+# 事前チェック：重複があるかどうか確認
+duplicate_groups = SongsKaraokeDeliveryModel
+                   .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
+                   .group('song_id, karaoke_delivery_model_id')
+                   .having('COUNT(*) > 1')
+
+if duplicate_groups.empty?
+  puts "✅ 重複は見つかりませんでした。修正の必要はありません。"
+  exit
+end
+
+puts "📋 検出された重複:"
+puts "  重複組数: #{duplicate_groups.count}組"
+
+total_records_before = SongsKaraokeDeliveryModel.count
+redundant_records = duplicate_groups.sum { |group| group.count - 1 }
+
+puts "  現在のレコード数: #{total_records_before}件"
+puts "  削除予定レコード数: #{redundant_records}件"
+puts "  修正後のレコード数: #{total_records_before - redundant_records}件"
+puts ""
+
+# 確認プロンプト
+print "続行しますか？ (yes/no): "
+confirmation = $stdin.gets.chomp.downcase
+unless confirmation == 'yes'
+  puts "処理をキャンセルしました。"
+  exit
+end
+
+# 統計情報を初期化
+stats = {
+  duplicate_groups_processed: 0,
+  records_deleted: 0,
+  errors: []
+}
+
+puts "\n🔧 重複修正開始..."
+
+ActiveRecord::Base.transaction do
+  duplicate_groups.each do |group|
+    # 該当する全レコードを取得
+    duplicate_records = SongsKaraokeDeliveryModel
+                        .where(song_id: group.song_id, karaoke_delivery_model_id: group.karaoke_delivery_model_id)
+                        .includes(:song, :karaoke_delivery_model)
+                        .order(:created_at)
+
+    song = duplicate_records.first.song
+    delivery_model = duplicate_records.first.karaoke_delivery_model
+
+    puts "  処理中: \"#{song.title}\" × \"#{delivery_model.name}\" (#{duplicate_records.count}件)"
+
+    # 最古のレコードを保持、その他を削除
+    records_to_keep = duplicate_records.first
+    records_to_delete = duplicate_records[1..]
+
+    puts "    保持: #{records_to_keep.id} (#{records_to_keep.created_at.strftime('%Y-%m-%d %H:%M:%S')})"
+
+    records_to_delete.each do |record|
+      puts "    削除: #{record.id} (#{record.created_at.strftime('%Y-%m-%d %H:%M:%S')})"
+      record.destroy!
+      stats[:records_deleted] += 1
+    end
+
+    stats[:duplicate_groups_processed] += 1
+  rescue StandardError => e
+    error_msg = "エラー: Song ID #{group.song_id} × DeliveryModel ID #{group.karaoke_delivery_model_id} - #{e.message}"
+    puts "    ❌ #{error_msg}"
+    stats[:errors] << error_msg
+    raise e # トランザクションをロールバック
+  end
+
+  puts "\n📈 修正結果:"
+  puts "  処理した重複組数: #{stats[:duplicate_groups_processed]}"
+  puts "  削除したレコード数: #{stats[:records_deleted]}"
+
+  if stats[:errors].any?
+    puts "  エラー数: #{stats[:errors].size}"
+    stats[:errors].each { |error| puts "    - #{error}" }
+    raise "エラーが発生したため処理を中止します"
+  end
+
+  # 修正後の確認
+  remaining_duplicates = SongsKaraokeDeliveryModel
+                         .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
+                         .group('song_id, karaoke_delivery_model_id')
+                         .having('COUNT(*) > 1')
+                         .count
+
+  raise "修正後も#{remaining_duplicates}組の重複が残っています" if remaining_duplicates.positive?
+
+  total_records_after = SongsKaraokeDeliveryModel.count
+  puts "  修正前レコード数: #{total_records_before}件"
+  puts "  修正後レコード数: #{total_records_after}件"
+  puts "  削除されたレコード数: #{total_records_before - total_records_after}件"
+
+  puts "\n✅ 修正完了！"
+end
+
+puts "\n🔍 修正後の確認:"
+puts "  以下のコマンドで重複がないことを確認してください:"
+puts "  docker compose run --rm web bin/rails r lib/check_song_delivery_model_duplicates.rb"
+
+puts "\n💡 今後の重複防止:"
+puts "  ユニーク制約を追加することを推奨します:"
+puts "  docker compose run --rm web bin/rails r lib/add_unique_constraint_to_song_delivery_models.rb"

--- a/lib/fix_song_delivery_model_duplicates.rb
+++ b/lib/fix_song_delivery_model_duplicates.rb
@@ -21,14 +21,14 @@ puts "⚠️  この操作は不可逆です。事前にデータベースのバ
 puts ""
 
 # 事前チェック：重複があるかどうか確認
-duplicate_combinations = ActiveRecord::Base.connection.execute(<<~SQL)
+duplicate_combinations = ActiveRecord::Base.connection.execute(<<~SQL.squish)
   SELECT song_id, karaoke_delivery_model_id, COUNT(*) as duplicate_count
   FROM songs_karaoke_delivery_models
   GROUP BY song_id, karaoke_delivery_model_id
   HAVING COUNT(*) > 1
 SQL
 
-if duplicate_combinations.count == 0
+if duplicate_combinations.count.zero?
   puts "✅ 重複は見つかりませんでした。修正の必要はありません。"
   exit
 end
@@ -64,10 +64,10 @@ ActiveRecord::Base.transaction do
   duplicate_combinations.each do |combination|
     song_id = combination['song_id']
     karaoke_delivery_model_id = combination['karaoke_delivery_model_id']
-    
+
     # 該当する全レコードを取得
     duplicate_records = SongsKaraokeDeliveryModel
-                        .where(song_id: song_id, karaoke_delivery_model_id: karaoke_delivery_model_id)
+                        .where(song_id:, karaoke_delivery_model_id:)
                         .includes(:song, :karaoke_delivery_model)
                         .order(:created_at)
 
@@ -107,7 +107,7 @@ ActiveRecord::Base.transaction do
   end
 
   # 修正後の確認
-  remaining_result = ActiveRecord::Base.connection.execute(<<~SQL)
+  remaining_result = ActiveRecord::Base.connection.execute(<<~SQL.squish)
     SELECT COUNT(*) as remaining_count
     FROM (
       SELECT song_id, karaoke_delivery_model_id

--- a/lib/fix_song_delivery_model_duplicates.rb
+++ b/lib/fix_song_delivery_model_duplicates.rb
@@ -23,7 +23,7 @@ puts ""
 # 事前チェック：重複があるかどうか確認
 duplicate_groups = SongsKaraokeDeliveryModel
                    .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
-                   .group('song_id, karaoke_delivery_model_id')
+                   .group(:song_id, :karaoke_delivery_model_id)
                    .having('COUNT(*) > 1')
 
 if duplicate_groups.empty?
@@ -105,7 +105,7 @@ ActiveRecord::Base.transaction do
   # 修正後の確認
   remaining_duplicates = SongsKaraokeDeliveryModel
                          .select('song_id, karaoke_delivery_model_id, COUNT(*) as count')
-                         .group('song_id, karaoke_delivery_model_id')
+                         .group(:song_id, :karaoke_delivery_model_id)
                          .having('COUNT(*) > 1')
                          .count
 

--- a/lib/normalize_delivery_model_names.rb
+++ b/lib/normalize_delivery_model_names.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# 配信機種名の正規化スクリプト
+#
+# 実行方法:
+#   docker compose run --rm web bin/rails r lib/normalize_delivery_model_names.rb
+#
+# 処理内容:
+#   1. 全ての配信機種名を正規化（空白除去、全角/半角統一）
+#   2. 正規化により重複が発生する場合は警告
+#   3. 処理結果の詳細レポート
+#
+# 注意事項:
+#   - 事前にバックアップを作成してください
+#   - 正規化により重複が発生する場合は手動対応が必要です
+
+puts "配信機種名の正規化を開始します..."
+
+validator = DeliveryModelValidator.new
+
+# 事前チェック: 正規化により重複が発生しないか確認
+puts "🔍 事前チェック: 正規化により重複が発生しないか確認中..."
+
+potential_duplicates = []
+KaraokeDeliveryModel.find_each do |model|
+  normalized_name = validator.normalize_name(model.name)
+  next if normalized_name == model.name
+
+  # 正規化後の名前で既存レコード（自分以外）があるかチェック
+  existing = KaraokeDeliveryModel.where(name: normalized_name, karaoke_type: model.karaoke_type)
+                                 .where.not(id: model.id)
+                                 .first
+
+  if existing
+    potential_duplicates << {
+      current: model,
+      normalized_name:,
+      existing:
+    }
+  end
+end
+
+if potential_duplicates.any?
+  puts "⚠️  正規化により以下の重複が発生します:"
+  potential_duplicates.each do |dup|
+    puts "  現在: \"#{dup[:current].name}\" → \"#{dup[:normalized_name]}\""
+    puts "  既存: \"#{dup[:existing].name}\" (ID: #{dup[:existing].id})"
+    puts "  対象ID: #{dup[:current].id}"
+    puts ""
+  end
+
+  puts "❌ 重複が発生するため、事前に以下のスクリプトを実行してください:"
+  puts "  docker compose run --rm web bin/rails r lib/fix_delivery_model_duplicates.rb"
+  exit 1
+end
+
+puts "✅ 重複は発生しません。正規化を実行します..."
+
+# 確認プロンプト
+print "続行しますか？ (yes/no): "
+confirmation = $stdin.gets.chomp.downcase
+unless confirmation == 'yes'
+  puts "処理をキャンセルしました。"
+  exit
+end
+
+# 正規化実行
+puts "\n🔧 正規化実行中..."
+updated_count = validator.normalize_existing_records
+
+# DeliveryModelManagerのキャッシュをクリア
+DeliveryModelManager.instance.clear_cache
+puts "📦 DeliveryModelManagerのキャッシュをクリアしました"
+
+puts "\n📊 正規化結果:"
+puts "  更新されたレコード数: #{updated_count}件"
+
+if updated_count.positive?
+  puts "\n✅ 正規化完了！"
+  puts "🔍 確認コマンド:"
+  puts "  docker compose run --rm web bin/rails r lib/check_delivery_model_duplicates.rb"
+else
+  puts "\n✅ 正規化の必要なレコードはありませんでした。"
+end


### PR DESCRIPTION
## 概要
楽曲と配信機種の関連付けテーブル (songs_karaoke_delivery_models) で同じ楽曲に同じ配信機種が重複して紐づく問題を解決する包括的な機能を実装しました。

## 実装内容

### 1. モデル層での重複防止
- `app/models/songs_karaoke_delivery_model.rb`
  - song_id + karaoke_delivery_model_id の uniqueness バリデーションを追加
  - `find_or_create_association` メソッドでレースコンディション対応
  - `create_associations_safely` メソッドでバッチ処理対応

### 2. 重複チェック機能
- `lib/check_song_delivery_model_duplicates.rb`
  - 既存の重複を検出して詳細レポートを生成
  - 楽曲名・配信機種名・作成日時を表示
  - 削除候補と保持レコードを明確に識別
  - 全体統計情報と修復方法を提案

### 3. 重複修正機能
- `lib/fix_song_delivery_model_duplicates.rb`
  - 安全なトランザクション内で重複を自動修正
  - 最古レコードを保持、新しいレコードを削除
  - 確認プロンプトと詳細な進捗表示
  - エラーハンドリングとロールバック機能

### 4. データベース制約
- `db/migrate/20250615030553_add_unique_constraint_to_songs_karaoke_delivery_models.rb`
  - song_id + karaoke_delivery_model_id の複合ユニークインデックス
  - データベースレベルでの整合性保証

### 5. 運用サポート
- `lib/add_unique_constraint_to_song_delivery_models.rb`
  - 重複データの事前チェック
  - マイグレーション自動実行
  - 制約追加後の検証
  - ステップバイステップのガイダンス

## 使用方法

### 重複チェック
```bash
docker compose run --rm web bin/rails r lib/check_song_delivery_model_duplicates.rb
```

### 重複修正
```bash
docker compose run --rm web bin/rails r lib/fix_song_delivery_model_duplicates.rb
```

### ユニーク制約追加
```bash
docker compose run --rm web bin/rails r lib/add_unique_constraint_to_song_delivery_models.rb
```

### 今後の関連付け作成
```ruby
# 安全な単一作成
SongsKaraokeDeliveryModel.find_or_create_association(song_id, delivery_model_id)

# 安全なバッチ作成
SongsKaraokeDeliveryModel.create_associations_safely(song_id, delivery_model_ids)
```

## テスト計画
- [ ] 重複チェックスクリプトの動作確認
- [ ] 重複修正スクリプトの動作確認（テストデータで）
- [ ] ユニーク制約追加の動作確認
- [ ] 新しいメソッドでの関連付け作成テスト
- [ ] エラーハンドリングの確認