### PR TITLE
Rubocopの設定を新しいプラグイン形式に更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from:
   - .rubocop_base.yml
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
## 概要
Rubocopの最新バージョンで推奨されているプラグイン形式に設定を更新しました。

## 変更内容
- `.rubocop.yml`の`require:`を`plugins:`に変更
- rubocop-performanceとrubocop-railsの警告を解消

## 背景
Rubocopの新しいバージョンでは、拡張機能の読み込み方法が変更され、`require`の代わりに`plugins`を使用することが推奨されています。

## 確認事項
- [x] Rubocopが正常に動作することを確認
- [x] 既存のルールが引き続き適用されることを確認