### PR TITLE
Claude GitHubアクションのレスポンスを日本語対応に修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,14 +42,14 @@ jobs:
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            このプルリクエストをレビューし、以下の観点からフィードバックを提供してください：
+            - コードの品質とベストプラクティス
+            - 潜在的なバグや問題
+            - パフォーマンスの考慮事項
+            - セキュリティの懸念事項
+            - テストカバレッジ
             
-            Be constructive and helpful in your feedback.
+            建設的で役に立つフィードバックを提供してください。返答は日本語でお願いします。
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,10 +53,11 @@ jobs:
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
+          custom_instructions: |
+            コーディング標準に従ってください
+            すべての新しいコードにはテストを必ず含めてください
+            Railsアプリケーションのベストプラクティスに従ってください
+            レスポンスは日本語で返してください
           
           # Optional: Custom environment variables for Claude
           # claude_env: |


### PR DESCRIPTION
## 概要
- `.github/workflows/claude-code-review.yml`のdirect_promptを日本語に変更
- `.github/workflows/claude.yml`にcustom_instructionsを追加して日本語レスポンスを指定

## 変更内容
- コードレビューの自動化プロンプトを日本語に翻訳
- レスポンスが日本語で返されるように設定
- 東方カラオケ管理サイトのプロジェクトに適したプロンプトに調整

## テスト計画
- [ ] PRでClaudeコードレビューアクションが正しく動作することを確認
- [ ] @claudeメンションでClaudeが日本語で返答することを確認