### PR TITLE
管理画面の運用フロー導線を整理

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1022,14 +1022,19 @@
 
 .admin-workflow-action-conditional,
 .admin-workflow-action-check,
-.admin-workflow-action-maintenance {
+.admin-workflow-action-maintenance,
+.admin-workflow-action-optional,
+.admin-workflow-action-manual {
   background: #fff;
   border-style: dashed;
 }
 
 .admin-workflow-action-conditional .admin-workflow-action-number,
 .admin-workflow-action-check .admin-workflow-action-number,
-.admin-workflow-action-maintenance .admin-workflow-action-number {
+.admin-workflow-action-maintenance .admin-workflow-action-number,
+.admin-workflow-action-optional .admin-workflow-action-number,
+.admin-workflow-action-manual .admin-workflow-action-number,
+.admin-workflow-step-manual .admin-workflow-action-number {
   background: #e8f1fb;
   color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
   font-size: 10px;
@@ -1141,6 +1146,11 @@
   grid-template-columns: 34px minmax(0, 1fr) auto;
   min-width: 0;
   padding: 10px;
+}
+
+.admin-workflow-step-manual {
+  background: #fff;
+  border-style: dashed;
 }
 
 .admin-workflow-step[data-admin-workflow-status="running"] {
@@ -1330,6 +1340,19 @@
 
 .admin-input {
   min-width: 260px;
+}
+
+.admin-checkbox-field {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+  min-height: 32px;
+}
+
+.admin-checkbox-field span {
+  color: color-mix(in oklab, var(--color-base-content) 72%, transparent);
+  font-size: 13px;
+  font-weight: 800;
 }
 
 .admin-search-field {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -882,11 +882,393 @@
   white-space: nowrap;
 }
 
+.admin-workflow-note .admin-section-heading {
+  align-items: start;
+  display: grid;
+  gap: 4px;
+}
+
+.admin-workflow-note .admin-section-heading p {
+  color: color-mix(in oklab, var(--color-base-content) 58%, transparent);
+  font-size: 13px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.admin-workflow-question-list {
+  color: color-mix(in oklab, var(--color-base-content) 66%, transparent);
+  display: grid;
+  font-size: 13px;
+  font-weight: 700;
+  gap: 6px;
+  margin: 12px 0 0;
+  padding-left: 18px;
+}
+
+.admin-workflow-route-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.admin-workflow-route-list li {
+  align-items: center;
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 8px;
+  min-height: 34px;
+  padding: 5px 12px 5px 6px;
+}
+
+.admin-workflow-route-list span {
+  align-items: center;
+  background: #071019;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  height: 24px;
+  justify-content: center;
+  width: 24px;
+}
+
+.admin-workflow-route-list strong {
+  font-size: 13px;
+}
+
+.admin-workflow-groups {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.admin-workflow-group {
+  background: var(--color-base-100);
+  border: 1px solid #e3edf7;
+  border-radius: 16px;
+  box-shadow: 0 14px 36px rgb(15 23 42 / 6%);
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.admin-workflow-group > header {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+}
+
+.admin-workflow-group-icon {
+  align-items: center;
+  background: color-mix(in oklab, var(--color-primary) 11%, #fff);
+  border: 1px solid color-mix(in oklab, var(--color-primary) 20%, #dfeaf6);
+  border-radius: 12px;
+  color: var(--color-primary);
+  display: inline-flex;
+  height: 42px;
+  justify-content: center;
+  width: 42px;
+}
+
+.admin-workflow-group h2 {
+  font-size: 18px;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.admin-workflow-group header p {
+  color: color-mix(in oklab, var(--color-base-content) 56%, transparent);
+  font-size: 12px;
+  font-weight: 700;
+  margin: 2px 0 0;
+}
+
+.admin-workflow-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-workflow-action {
+  align-items: center;
+  appearance: none;
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 12px;
+  color: var(--color-base-content);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 10px;
+  grid-template-columns: 30px minmax(0, 1fr) 18px;
+  min-height: 74px;
+  padding: 10px;
+  text-align: left;
+  text-decoration: none;
+  width: 100%;
+}
+
+.admin-workflow-action:hover {
+  background: #eef7ff;
+  border-color: #c6ddf5;
+}
+
+.admin-workflow-action-conditional,
+.admin-workflow-action-check,
+.admin-workflow-action-maintenance {
+  background: #fff;
+  border-style: dashed;
+}
+
+.admin-workflow-action-conditional .admin-workflow-action-number,
+.admin-workflow-action-check .admin-workflow-action-number,
+.admin-workflow-action-maintenance .admin-workflow-action-number {
+  background: #e8f1fb;
+  color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+  font-size: 10px;
+  width: 34px;
+}
+
+.admin-workflow-run-link {
+  align-items: center;
+  background: #071019;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 11px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.admin-workflow-header-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-workflow-header-actions form {
+  margin: 0;
+}
+
+.admin-workflow-runner {
+  display: grid;
+  gap: 14px;
+}
+
+.admin-workflow-status {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.admin-workflow-status-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.admin-workflow-status-grid div {
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 10px;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.admin-workflow-status-grid span {
+  color: color-mix(in oklab, var(--color-base-content) 56%, transparent);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.admin-workflow-status-grid strong {
+  font-size: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-workflow-parallel-note {
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 10px;
+  color: color-mix(in oklab, var(--color-base-content) 66%, transparent);
+  font-size: 13px;
+  font-weight: 800;
+  margin: 0;
+  padding: 10px 12px;
+}
+
+.admin-workflow-current {
+  background: color-mix(in oklab, var(--color-primary) 9%, #fff);
+  border: 1px solid color-mix(in oklab, var(--color-primary) 18%, #dfeaf6);
+  border-radius: 10px;
+  color: color-mix(in oklab, var(--color-primary) 76%, #111827);
+  font-size: 13px;
+  font-weight: 800;
+  margin: 0;
+  padding: 10px 12px;
+}
+
+.admin-workflow-step-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.admin-workflow-step {
+  align-items: center;
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 12px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  min-width: 0;
+  padding: 10px;
+}
+
+.admin-workflow-step[data-admin-workflow-status="running"] {
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 12%);
+}
+
+.admin-workflow-step[data-admin-workflow-status="completed"] {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.admin-workflow-step[data-admin-workflow-status="failed"] {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.admin-workflow-step-body {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.admin-workflow-step-body > span:first-child,
+.admin-workflow-step-body small,
+.admin-workflow-step-progress {
+  color: color-mix(in oklab, var(--color-base-content) 56%, transparent);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.admin-workflow-step-body strong {
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.admin-workflow-step-progress {
+  color: color-mix(in oklab, var(--color-primary) 72%, #111827);
+}
+
+.admin-workflow-detail-group {
+  margin-top: 14px;
+}
+
+.admin-workflow-action-number {
+  align-items: center;
+  background: #071019;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.admin-workflow-action-body {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.admin-workflow-action-body span:first-child,
+.admin-workflow-action-body small,
+.admin-workflow-action-tags {
+  color: color-mix(in oklab, var(--color-base-content) 56%, transparent);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.admin-workflow-action-body strong {
+  font-size: 14px;
+  line-height: 1.25;
+}
+
+.admin-workflow-action-body strong,
+.admin-workflow-action-body small,
+.admin-workflow-action-body span:first-child,
+.admin-workflow-action-tags {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-workflow-action-tags {
+  color: color-mix(in oklab, var(--color-primary) 72%, #111827);
+}
+
+.admin-workflow-action > .admin-icon {
+  color: color-mix(in oklab, var(--color-primary) 70%, #111827);
+}
+
+.admin-workflow-metrics {
+  border-top: 1px solid #edf3f9;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding-top: 12px;
+}
+
+.admin-workflow-metric {
+  color: var(--color-base-content);
+  display: grid;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.admin-workflow-metric span,
+.admin-workflow-metric small {
+  color: color-mix(in oklab, var(--color-base-content) 54%, transparent);
+  font-size: 11px;
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-workflow-metric strong {
+  font-size: 22px;
+  line-height: 1.1;
+}
+
 .admin-index-toolbar {
   align-items: stretch;
   display: grid;
   gap: 14px;
-  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-columns: minmax(0, 1fr);
   margin-bottom: 16px;
   width: 100%;
 }
@@ -1242,6 +1624,208 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.admin-operation-guide {
+  flex: 0 0 auto;
+  margin-bottom: 10px;
+}
+
+.admin-operation-guide.admin-control-panel {
+  height: auto;
+  min-height: 0;
+  padding: 0;
+}
+
+.admin-operation-guide:not([open]) {
+  display: block;
+  box-shadow: 0 8px 18px rgb(15 23 42 / 5%);
+  min-height: 42px;
+}
+
+.admin-operation-guide:not([open]) .admin-operation-guide-groups {
+  display: none;
+}
+
+.admin-operation-guide[open] {
+  display: block;
+  padding-bottom: 12px;
+}
+
+.admin-operation-guide-summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 40px;
+  padding: 8px 10px;
+}
+
+.admin-operation-guide-summary > div {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.admin-operation-guide-summary::-webkit-details-marker {
+  display: none;
+}
+
+.admin-operation-guide .admin-operation-guide-summary h2 {
+  font-size: 13px;
+  line-height: 1.2;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-operation-guide-summary > span:last-child {
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 999px;
+  color: color-mix(in oklab, var(--color-base-content) 56%, transparent);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  padding: 5px 8px;
+  white-space: nowrap;
+}
+
+.admin-operation-guide-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.admin-operation-guide-kicker {
+  color: color-mix(in oklab, var(--color-primary) 72%, #111827);
+  flex: 0 1 auto;
+  font-size: 11px;
+  font-weight: 800;
+  max-width: min(42vw, 220px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-operation-guide-groups {
+  display: grid;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 0 12px;
+}
+
+.admin-operation-guide-group {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-operation-guide-group h3 {
+  color: color-mix(in oklab, var(--color-base-content) 62%, transparent);
+  font-size: 12px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.admin-operation-guide-list {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.admin-operation-guide-item {
+  align-items: stretch;
+  background: #f8fbff;
+  border: 1px solid #dfeaf6;
+  border-radius: 12px;
+  color: var(--color-base-content);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 34px minmax(0, 1fr);
+  min-height: 112px;
+  padding: 12px;
+  text-decoration: none;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.admin-operation-guide-item:hover {
+  background: #eef7ff;
+  border-color: #c6ddf5;
+  box-shadow: 0 12px 28px rgb(15 23 42 / 8%);
+  transform: translateY(-1px);
+}
+
+.admin-operation-guide-icon {
+  align-items: center;
+  background: #fff;
+  border: 1px solid #dce7f3;
+  border-radius: 10px;
+  color: color-mix(in oklab, var(--color-primary) 78%, #111827);
+  display: inline-flex;
+  height: 34px;
+  justify-content: center;
+  width: 34px;
+}
+
+.admin-operation-guide-body {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.admin-operation-guide-body strong {
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.admin-operation-guide-body > span:not(.admin-operation-guide-meta) {
+  color: color-mix(in oklab, var(--color-base-content) 58%, transparent);
+  display: -webkit-box;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.admin-operation-guide-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.admin-operation-guide-meta small {
+  background: #fff;
+  border: 1px solid #dce7f3;
+  border-radius: 999px;
+  color: color-mix(in oklab, var(--color-base-content) 58%, transparent);
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  padding: 4px 7px;
+}
+
+.admin-operation-guide-cta {
+  align-items: center;
+  align-self: end;
+  color: color-mix(in oklab, var(--color-primary) 78%, #111827);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  gap: 4px;
+  grid-column: 2;
+  justify-self: start;
 }
 
 .admin-select-column {
@@ -1967,6 +2551,27 @@ th.admin-actions-column {
   }
 
   .admin-dashboard-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-operation-guide-list,
+  .admin-workflow-groups {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-workflow-action {
+    grid-template-columns: 30px minmax(0, 1fr);
+  }
+
+  .admin-workflow-action > .admin-icon {
+    display: none;
+  }
+
+  .admin-workflow-metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-workflow-status-grid {
     grid-template-columns: 1fr;
   }
 

--- a/app/controllers/admin/resources_controller.rb
+++ b/app/controllers/admin/resources_controller.rb
@@ -413,7 +413,10 @@ module Admin
     end
 
     def scalar_param(key)
-      params.permit(key)[key]
+      value = params[key]
+      return nil if value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+
+      value
     end
 
     def operation_progress_id
@@ -422,7 +425,7 @@ module Admin
     end
 
     def operation_job_params(progress_id)
-      permitted = params.permit(:operation, selected_ids: [], operation_fields: operation_field_param_keys)
+      permitted = params.permit(:operation, :operation_progress_id, selected_ids: [], operation_fields: operation_field_param_keys)
       permitted.to_h.merge('operation_progress_id' => progress_id)
     end
 

--- a/app/controllers/admin/workflow_controller.rb
+++ b/app/controllers/admin/workflow_controller.rb
@@ -1,0 +1,128 @@
+module Admin
+  class WorkflowController < BaseController
+    def index
+      @workflow_order = ['JOYSOUND(うたスキ)', 'JOYSOUND', 'DAM']
+      @workflow_groups = workflow_groups
+      @workflow_operation_resources = @workflow_groups.flat_map { |group| group[:actions].map { |action| action[:resource] } }.uniq
+      @workflow_notes = workflow_notes
+    end
+
+    def show
+      @workflow = WorkflowDefinition.fetch(params[:workflow_key])
+      @workflow_groups = workflow_groups([@workflow])
+      @workflow_operation_resources = @workflow_groups.flat_map { |group| group[:actions].map { |action| action[:resource] } }.uniq
+      @active_workflow_run = active_workflow_run_for(@workflow)
+      @workflow_run_id = params[:run_id].presence || active_run_id_for_current_workflow
+      @workflow_run = WorkflowRunProgress.read(@workflow_run_id) if @workflow_run_id.present?
+    end
+
+    def run
+      workflow = WorkflowDefinition.fetch(params[:workflow_key])
+      raise ActionController::RoutingError, 'Not Found' if workflow.key == 'common'
+
+      if (active_run = active_workflow_run_for(workflow))
+        respond_to do |format|
+          format.json { render json: active_run.merge(message: '既に自動実行中です。'), status: :conflict }
+          format.html do
+            redirect_to(
+              admin_workflow_steps_path(active_run[:workflow_key], run_id: active_run[:id]),
+              alert: "#{active_run[:workflow_label]}を実行中のため、新しい自動実行は開始しませんでした。"
+            )
+          end
+        end
+        return
+      end
+
+      progress_id = SecureRandom.uuid
+
+      WorkflowRunProgress.create!(progress_id, workflow:)
+      WorkflowRunJob.perform_later(workflow_key: workflow.key, progress_id:)
+
+      respond_to do |format|
+        format.json { render json: WorkflowRunProgress.read(progress_id), status: :accepted }
+        format.html { redirect_to admin_workflow_steps_path(workflow.key, run_id: progress_id), notice: "#{workflow.label}を開始しました。" }
+      end
+    end
+
+    def progress
+      WorkflowDefinition.fetch(params[:workflow_key])
+
+      render json: WorkflowRunProgress.read(params[:run_id])
+    end
+
+    private
+
+    def active_workflow_run_for(workflow)
+      record = WorkflowRunProgress.active_conflict_for(workflow)
+      return unless record
+
+      payload = WorkflowRunProgress.read(record.id)
+      {
+        id: record.id,
+        workflow_key: payload.dig(:workflow, :workflow_key),
+        workflow_label: payload.dig(:workflow, :workflow_label),
+        state: payload[:state],
+        status: payload[:status],
+        label: payload[:label],
+        percentage: payload[:percentage],
+        updated_at: payload[:updated_at]
+      }
+    end
+
+    def active_run_id_for_current_workflow
+      return unless @active_workflow_run&.dig(:workflow_key) == @workflow.key
+
+      @active_workflow_run[:id]
+    end
+
+    def workflow_groups(definitions = WorkflowDefinition.listed)
+      definitions.map do |definition|
+        {
+          key: definition.key,
+          label: definition.label,
+          description: definition.description,
+          icon: definition.icon,
+          actions: workflow_actions(definition),
+          metrics: workflow_metrics(definition)
+        }
+      end
+    end
+
+    def workflow_actions(definition)
+      definition.stages.flat_map(&:branches).flat_map(&:steps).filter_map do |step|
+        resource = ResourceRegistry.fetch(step.resource_key)
+        operation = resource.operations.find { |item| item.key == step.operation_key || item.handler == step.operation_key.to_sym || item.method_name == step.operation_key.to_sym }
+        next unless workflow_operation_visible?(operation)
+
+        {
+          resource:,
+          operation:,
+          path: admin_resource_collection_operation_path(resource, operation.key),
+          note: step.note,
+          cadence: step.cadence,
+          kind: step.kind,
+          numbered: step.numbered
+        }
+      end
+    end
+
+    def workflow_operation_visible?(operation)
+      operation.present? && operation.selection != :required
+    end
+
+    def workflow_metrics(definition)
+      definition.metrics.map do |metric|
+        metric.merge(path: public_send(metric[:route_name], metric[:route_options]))
+      end
+    end
+
+    def workflow_notes
+      [
+        '全体で回す時は JOYSOUND(うたスキ) → JOYSOUND → DAM。必要な配信種別だけ単独実行してもよい。',
+        'JOYSOUNDアーティスト読み補完は、JOYSOUND候補をカラオケ楽曲へ登録した後でないと対象アーティストが作られない。',
+        'DAM候補一覧取得は内部リトライとページ巡回を持つが、最終件数の照合まではしていないため、件数が不自然なら再実行する。',
+        'ミュージックポストのフルメンテナンスは手順4〜6と期限切れ整理のまとめ実行。手順1〜3の代替ではない。'
+      ]
+    end
+  end
+end

--- a/app/helpers/admin/icons_helper.rb
+++ b/app/helpers/admin/icons_helper.rb
@@ -3,6 +3,7 @@ module Admin
     ICONS_PATH = Rails.root.join('node_modules/lucide-static/icons')
     ICON_ALIASES = {
       dashboard: 'layout-dashboard',
+      workflow: 'list-checks',
       originals: 'book-open',
       original_songs: 'music',
       karaoke_delivery_models: 'radio',

--- a/app/helpers/admin/operations_helper.rb
+++ b/app/helpers/admin/operations_helper.rb
@@ -19,6 +19,13 @@ module Admin
       '実行内容を確認'
     end
 
+    def admin_resource_operation_visible?(resource, operation, operation_scope)
+      return true unless operation_scope == :collection
+      return true if operation.selection != :none
+
+      !WorkflowDefinition.operation_pair?(resource.key, operation.key)
+    end
+
     def admin_workflow_step_status_label(step_payload, running: false, numbered: true)
       return '個別実行のみ' unless numbered
       return '未実行' unless running

--- a/app/helpers/admin/operations_helper.rb
+++ b/app/helpers/admin/operations_helper.rb
@@ -1,0 +1,43 @@
+module Admin
+  module OperationsHelper
+    def admin_operation_summary(operation)
+      truncate(strip_tags(operation.description.to_s.squish), length: 92)
+    end
+
+    def admin_operation_status_labels(operation)
+      labels = []
+      labels << '選択必須' if operation.selection == :required
+      labels << '入力あり' if operation.inputs.present?
+      labels << 'バックグラウンド' if operation.async
+      labels.presence || ['すぐ実行']
+    end
+
+    def admin_operation_cta(operation)
+      return '対象を選択して実行' if operation.selection == :required
+      return '入力して実行' if operation.inputs.present?
+
+      '実行内容を確認'
+    end
+
+    def admin_workflow_step_status_label(step_payload, running: false, numbered: true)
+      return '個別実行のみ' unless numbered
+      return '未実行' unless running
+
+      status = step_payload&.dig(:status) || 'pending'
+      child_progress = step_payload&.dig(:progress) || {}
+      label = case status
+              when 'pending' then '順番待ち'
+              when 'running' then child_progress[:label].presence || '実行中'
+              when 'completed' then child_progress[:detail].presence || '完了'
+              when 'failed' then step_payload[:error].presence || child_progress[:detail].presence || '失敗'
+              else status
+              end
+
+      if status == 'running'
+        percentage = child_progress[:percentage].to_i.clamp(0, 100)
+        label = "#{label} #{percentage}%"
+      end
+      label
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -190,6 +190,12 @@ const updateAdminResourceSelectionState = () => {
   document.querySelectorAll("[data-admin-operation-selection-count]").forEach((item) => {
     item.textContent = selectedCount.toLocaleString()
   })
+  document.querySelectorAll("[data-admin-operation-form]").forEach((form) => {
+    const note = form.querySelector("[data-admin-operation-selection-note]")
+    if (!note || form.dataset.adminOperationSelectionRequired !== "true") return
+
+    note.textContent = selectedCount > 0 ? "選択した対象で実行できます。" : "対象を選択してください。"
+  })
   updateAdminOperationSubmitStates()
 }
 
@@ -217,43 +223,46 @@ const setupAdminResourceSelection = () => {
 document.addEventListener("DOMContentLoaded", setupAdminResourceSelection)
 
 const setupAdminOperationModal = () => {
-  const modal = document.querySelector("[data-admin-operation-modal]")
-  if (!modal || modal.dataset.initialized === "true") return
+  document.querySelectorAll("[data-admin-operation-modal]").forEach((modal) => {
+    if (modal.dataset.initialized === "true") return
 
-  modal.dataset.initialized = "true"
-  const title = modal.querySelector("[data-admin-operation-modal-title]")
-  const panels = Array.from(modal.querySelectorAll("[data-admin-operation-panel]"))
-  const closeButton = modal.querySelector("[data-admin-operation-modal-close]")
+    modal.dataset.initialized = "true"
+    const title = modal.querySelector("[data-admin-operation-modal-title]")
+    const panels = Array.from(modal.querySelectorAll("[data-admin-operation-panel]"))
+    const closeButton = modal.querySelector("[data-admin-operation-modal-close]")
+    const resourceKey = modal.dataset.adminOperationResource
 
-  const showPanel = (operationKey, label) => {
-    let activePanel
-    panels.forEach((panel) => {
-      const active = panel.dataset.adminOperationPanel === operationKey
-      panel.hidden = !active
-      if (active) activePanel = panel
+    const showPanel = (operationKey, label) => {
+      let activePanel
+      panels.forEach((panel) => {
+        const active = panel.dataset.adminOperationPanel === operationKey
+        panel.hidden = !active
+        if (active) activePanel = panel
+      })
+      if (title) title.textContent = label
+      updateAdminResourceSelectionState()
+      activePanel?.dispatchEvent(new Event("admin-operation-panel-open"))
+    }
+
+    document.querySelectorAll("[data-admin-operation-trigger]").forEach((trigger) => {
+      if (trigger.dataset.modalInitialized === "true") return
+      if (resourceKey && trigger.dataset.adminOperationResource !== resourceKey) return
+
+      trigger.dataset.modalInitialized = "true"
+      trigger.addEventListener("click", (event) => {
+        const operationKey = trigger.dataset.adminOperationKey
+        const panel = panels.find((item) => item.dataset.adminOperationPanel === operationKey)
+        if (!panel || !modal.showModal) return
+
+        event.preventDefault()
+        trigger.closest("details")?.removeAttribute("open")
+        showPanel(operationKey, trigger.dataset.adminOperationLabel || trigger.textContent.trim())
+        modal.showModal()
+      })
     })
-    if (title) title.textContent = label
-    updateAdminResourceSelectionState()
-    activePanel?.dispatchEvent(new Event("admin-operation-panel-open"))
-  }
 
-  document.querySelectorAll("[data-admin-operation-trigger]").forEach((trigger) => {
-    if (trigger.dataset.modalInitialized === "true") return
-
-    trigger.dataset.modalInitialized = "true"
-    trigger.addEventListener("click", (event) => {
-      const operationKey = trigger.dataset.adminOperationKey
-      const panel = panels.find((item) => item.dataset.adminOperationPanel === operationKey)
-      if (!panel || !modal.showModal) return
-
-      event.preventDefault()
-      trigger.closest("details")?.removeAttribute("open")
-      showPanel(operationKey, trigger.textContent.trim())
-      modal.showModal()
-    })
+    closeButton?.addEventListener("click", () => modal.close())
   })
-
-  closeButton?.addEventListener("click", () => modal.close())
 }
 
 document.addEventListener("DOMContentLoaded", setupAdminOperationModal)
@@ -359,12 +368,13 @@ const setupAdminOperationForms = () => {
       updateAdminOperationSubmitStates()
     }
 
-    const finishProgress = () => {
+    const finishProgress = (payload = {}) => {
       if (progress?.hidden || progressPhase === "finished") return
 
       progressPhase = "finished"
       activateProgressStep("finish")
-      updateProgress(100, "完了", inlineConfirmation ? "処理が完了しました。ダイアログを閉じます..." : "処理が完了しました。画面を切り替えています...")
+      const completedLabel = payload.detail || payload.label || (inlineConfirmation ? "処理が完了しました。ダイアログを閉じます..." : "処理が完了しました。画面を切り替えています...")
+      updateProgress(100, "完了", completedLabel)
       if (elapsedTimer) window.clearInterval(elapsedTimer)
       if (pollTimer) window.clearInterval(pollTimer)
       if (inlineConfirmation && operationModal?.open) {
@@ -393,7 +403,7 @@ const setupAdminOperationForms = () => {
       }
 
       if (payload.state === "running") activateProgressStep("execute")
-      if (payload.state === "completed") finishProgress()
+      if (payload.state === "completed") finishProgress(payload)
       if (payload.state === "failed") {
         progressPhase = "failed"
         updateProgress(lastServerPercentage, "エラー", payload.detail || label)
@@ -591,3 +601,85 @@ const setupAdminOperationForms = () => {
 }
 
 document.addEventListener("DOMContentLoaded", setupAdminOperationForms)
+
+const setupAdminWorkflowRunner = () => {
+  document.querySelectorAll("[data-admin-workflow-runner]").forEach((runner) => {
+    if (runner.dataset.initialized === "true") return
+    if (!runner.dataset.adminWorkflowRunId || !runner.dataset.adminWorkflowProgressUrl) return
+
+    runner.dataset.initialized = "true"
+    const stepItems = Array.from(runner.querySelectorAll("[data-admin-workflow-step]"))
+    const statusPanel = document.querySelector("[data-admin-workflow-status]")
+    const statusLabel = statusPanel?.querySelector("[data-admin-workflow-status-label]")
+    const statusState = statusPanel?.querySelector("[data-admin-workflow-status-state]")
+    const statusPercent = statusPanel?.querySelector("[data-admin-workflow-status-percent]")
+    const statusCurrent = statusPanel?.querySelector("[data-admin-workflow-status-current]")
+    const statusCount = statusPanel?.querySelector("[data-admin-workflow-status-count]")
+    const currentStepLabel = runner.querySelector("[data-admin-workflow-current-step]")
+
+    const applyStatus = (payload) => {
+      const currentStep = payload.workflow?.current_step
+      const currentText = currentStep?.label || (payload.state === "completed" ? "完了" : "確認中")
+
+      if (statusPanel) {
+        if (statusLabel) statusLabel.textContent = payload.label || "実行状況を確認しています"
+        if (statusState) statusState.textContent = payload.status || payload.state || "確認中"
+        if (statusPercent) statusPercent.textContent = `${Number.parseInt(payload.percentage || "0", 10)}%`
+        if (statusCurrent) statusCurrent.textContent = currentText
+      }
+      if (currentStepLabel) currentStepLabel.textContent = `現在: ${currentText}`
+      if (statusPanel && statusCount) {
+        const workflow = payload.workflow || {}
+        statusCount.textContent = `${Number.parseInt(workflow.completed_steps || "0", 10)} / ${Number.parseInt(workflow.total_steps || "0", 10)}`
+      }
+    }
+
+    const applyStep = (step) => {
+      const item = stepItems.find((candidate) => candidate.dataset.adminWorkflowStep === step.key)
+      if (!item) return
+
+      item.dataset.adminWorkflowStatus = step.status
+      const progress = item.querySelector("[data-admin-workflow-step-progress]")
+      const childProgress = step.progress || {}
+      const labels = {
+        pending: "順番待ち",
+        running: childProgress.label || "実行中",
+        completed: childProgress.detail || "完了",
+        failed: step.error || childProgress.detail || "失敗",
+        manual: "個別実行のみ",
+      }
+      if (progress) {
+        progress.textContent = labels[step.status] || step.status
+        if (step.status === "running" && Number.isFinite(Number.parseInt(childProgress.percentage || "0", 10))) {
+          progress.textContent += ` ${Number.parseInt(childProgress.percentage || "0", 10)}%`
+        }
+      }
+    }
+
+    const poll = async () => {
+      try {
+        const response = await fetch(runner.dataset.adminWorkflowProgressUrl, {
+          headers: {
+            Accept: "application/json",
+            "X-Requested-With": "XMLHttpRequest",
+          },
+        })
+        if (!response.ok) return
+
+        const payload = await response.json()
+        applyStatus(payload)
+        payload.workflow?.steps?.forEach(applyStep)
+        runner.dataset.adminWorkflowState = payload.state
+        if (payload.state === "completed" || payload.state === "failed") return
+        window.setTimeout(poll, 1500)
+      } catch (error) {
+        console.error(error)
+        window.setTimeout(poll, 3000)
+      }
+    }
+
+    poll()
+  })
+}
+
+document.addEventListener("DOMContentLoaded", setupAdminWorkflowRunner)

--- a/app/jobs/admin/workflow_run_job.rb
+++ b/app/jobs/admin/workflow_run_job.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Admin
+  class WorkflowRunJob < ApplicationJob
+    queue_as :admin_operations
+
+    def perform(workflow_key:, progress_id:)
+      workflow = WorkflowDefinition.fetch(workflow_key)
+      WorkflowRunProgress.start!(progress_id, workflow:)
+
+      workflow.stages.each do |stage|
+        WorkflowRunProgress.update_stage!(progress_id, label: "#{stage.label}を実行しています")
+        if stage.parallel
+          run_stage_in_parallel(progress_id, stage)
+        else
+          stage.branches.each { |branch| run_branch(progress_id, stage, branch) }
+        end
+      end
+
+      WorkflowRunProgress.complete!(progress_id, workflow:)
+    rescue StandardError => e
+      WorkflowRunProgress.fail!(progress_id, message: e.message)
+      Rails.logger.error(e.full_message)
+      raise
+    end
+
+    private
+
+    def run_stage_in_parallel(progress_id, stage)
+      threads = stage.branches.map do |branch|
+        Thread.new do
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection do
+              run_branch(progress_id, stage, branch)
+            end
+          end
+        end
+      end
+      threads.each(&:join)
+      failed_thread = threads.find { |thread| thread[:error] }
+      raise failed_thread[:error] if failed_thread
+    end
+
+    def run_branch(progress_id, stage, branch)
+      branch.steps.select(&:numbered).each do |step|
+        run_step(progress_id, stage, branch, step)
+      end
+    rescue StandardError => e
+      Thread.current[:error] = e
+      raise
+    end
+
+    def run_step(progress_id, stage, branch, step)
+      resource = ResourceRegistry.fetch(step.resource_key)
+      operation = resource.operations.find { |item| item.key == step.operation_key } ||
+                  raise(ArgumentError, "指定されたアクションは見つかりません: #{step.operation_key}")
+      child_progress_id = SecureRandom.uuid
+      step_key = "#{stage.key}:#{branch.key}:#{step.key}"
+
+      WorkflowRunProgress.mark_step!(progress_id, step_key, status: 'running', progress_id: child_progress_id)
+      OperationProgress.enqueue!(child_progress_id, label: "#{operation.label}を開始待ちです")
+      OperationRunner.new(
+        resource:,
+        operation:,
+        record: nil,
+        params: { operation_progress_id: child_progress_id },
+        scope: resource.model.all
+      ).run
+      WorkflowRunProgress.mark_step!(progress_id, step_key, status: 'completed', progress_id: child_progress_id)
+    rescue StandardError => e
+      WorkflowRunProgress.mark_step!(progress_id, step_key, status: 'failed', progress_id: child_progress_id, error: e.message) if defined?(step_key)
+      raise
+    end
+  end
+end

--- a/app/models/admin/operation_progress.rb
+++ b/app/models/admin/operation_progress.rb
@@ -32,10 +32,10 @@ module Admin
         write(id, read(id).merge(normalize(attributes)).merge(updated_at: Time.current.iso8601))
       end
 
-      def complete!(id, label:)
+      def complete!(id, label:, detail: nil)
         return unless valid_id?(id)
 
-        update!(id, state: 'completed', percentage: 100, status: '完了', label:, detail: nil)
+        update!(id, state: 'completed', percentage: 100, status: '完了', label:, detail:)
       end
 
       def fail!(id, message:)

--- a/app/models/admin/operation_runner.rb
+++ b/app/models/admin/operation_runner.rb
@@ -20,10 +20,17 @@ module Admin
     end
 
     def run
+      started_at = Time.current
+      change_baseline = change_baseline_snapshot
       OperationProgress.start!(progress_id, label: operation.label)
       result = operation.handler.blank? ? run_method_operation : run_handler_operation
+      change_summary = summarize_changes(change_baseline, started_at)
 
-      OperationProgress.complete!(progress_id, label: result.message.presence || '処理が完了しました')
+      OperationProgress.complete!(
+        progress_id,
+        label: result.message.presence || '処理が完了しました',
+        detail: change_summary
+      )
       result
     rescue StandardError => e
       OperationProgress.fail!(progress_id, message: e.message)
@@ -110,6 +117,8 @@ module Admin
       end
     end
 
+    alias register_joysound_music_post_songs fetch_joysound_music_post_song
+
     def refresh_joysound_music_post_song(progress: nil)
       result = JoysoundMusicPostManager.new.refresh_songs_efficiently(progress:)
       if result[:errors].any?
@@ -119,6 +128,8 @@ module Admin
       end
     end
 
+    alias verify_joysound_music_post_songs refresh_joysound_music_post_song
+
     def update_joysound_music_post_delivery_deadline_dates(progress: nil)
       result = JoysoundMusicPostManager.new.update_delivery_deadlines_optimized(progress:)
       if result[:errors].any?
@@ -127,6 +138,8 @@ module Admin
         message("更新処理が正常に完了しました。処理件数: #{result[:total_processed]}件、更新件数: #{result[:updated]}件")
       end
     end
+
+    alias sync_joysound_music_post_delivery_deadlines update_joysound_music_post_delivery_deadline_dates
 
     def validate_display_artist_urls(progress: nil)
       result = DisplayArtistUrlValidator.new(delete_invalid: false, progress:).validate_all
@@ -207,6 +220,8 @@ module Admin
       summary += "\n#{total_errors}件のエラーが発生しました。詳細はログを確認してください。" if total_errors.positive?
       message(summary)
     end
+
+    alias run_full_joysound_music_post_maintenance perform_full_joysound_music_post_maintenance
 
     private
 
@@ -299,6 +314,58 @@ module Admin
 
     def tsv_file?(uploaded_file)
       uploaded_file.content_type.in?(%w[text/tab-separated-values text/plain]) || uploaded_file.original_filename.ends_with?('.tsv')
+    end
+
+    def change_baseline_snapshot
+      tracked_change_models.to_h { |model| [model.name, model.count] }
+    end
+
+    def summarize_changes(baseline, started_at)
+      summaries = tracked_change_models.filter_map do |model|
+        summarize_model_changes(model, baseline.fetch(model.name, 0), started_at)
+      end
+
+      return '変更なし（追加・更新・削除はありません）' if summaries.blank?
+
+      "DB変更: #{summaries.join('、')}"
+    end
+
+    def summarize_model_changes(model, before_count, started_at)
+      after_count = model.count
+      created_count = timestamp_count(model, :created_at, started_at)
+      updated_count = updated_existing_count(model, started_at)
+      deleted_count = [before_count + created_count - after_count, 0].max
+      parts = []
+      parts << "追加#{created_count}件" if created_count.positive?
+      parts << "更新#{updated_count}件" if updated_count.positive?
+      parts << "削除#{deleted_count}件" if deleted_count.positive?
+      return if parts.blank?
+
+      "#{change_model_label(model)} #{parts.join(' ')}"
+    end
+
+    def timestamp_count(model, column, started_at)
+      return 0 unless model.column_names.include?(column.to_s)
+
+      model.where(column => started_at..).count
+    end
+
+    def updated_existing_count(model, started_at)
+      return 0 unless model.column_names.include?('updated_at')
+      return timestamp_count(model, :updated_at, started_at) unless model.column_names.include?('created_at')
+
+      model.where(updated_at: started_at..).where(model.arel_table[:created_at].lt(started_at)).count
+    end
+
+    def tracked_change_models
+      @tracked_change_models ||= ResourceRegistry.all.values.map(&:model).uniq.select do |model|
+        model.table_exists? && model.column_names.intersect?(%w[created_at updated_at])
+      end
+    end
+
+    def change_model_label(model)
+      @change_model_labels ||= ResourceRegistry.all.values.to_h { |resource| [resource.model.name, resource.label] }
+      @change_model_labels.fetch(model.name, model.model_name.human)
     end
 
     def message(text)

--- a/app/models/admin/operation_runner.rb
+++ b/app/models/admin/operation_runner.rb
@@ -92,20 +92,20 @@ module Admin
       url = params.dig(:operation_fields, :dam_song_url).to_s
       raise ArgumentError, 'DAMの楽曲URLではありません。' unless url.start_with?(Constants::Karaoke::Dam::SONG_URL)
 
-      progress&.call(percentage: 25, status: 'DAM楽曲取得中', label: '指定URLからDAM楽曲を取得しています', detail: nil)
+      progress&.call(percentage: 25, status: 'DAM候補追加中', label: '指定URLからDAM候補を取得しています', detail: nil)
       DamSong.fetch_dam_song(url)
-      progress&.call(percentage: 96, status: 'DAM楽曲取得中', label: 'DAM楽曲の保存が完了しました', detail: nil)
-      message('DAM楽曲を取得しました。')
+      progress&.call(percentage: 96, status: 'DAM候補追加中', label: 'DAM候補の保存が完了しました', detail: nil)
+      message('DAM候補を追加しました。')
     end
 
     def fetch_joysound_detail(progress: nil)
       url = params.dig(:operation_fields, :joysound_url).to_s
       raise ArgumentError, 'JOYSOUNDの楽曲URLではありません。' unless url.start_with?("#{Constants::Karaoke::Joysound::SEARCH_URL}/")
 
-      progress&.call(percentage: 25, status: 'JOYSOUND詳細取得中', label: '指定URLからJOYSOUND詳細を取得しています', detail: nil)
+      progress&.call(percentage: 25, status: 'JOYSOUND候補追加中', label: '指定URLからJOYSOUND候補を取得しています', detail: nil)
       JoysoundSong.fetch_joysound_song_direct(url:)
-      progress&.call(percentage: 96, status: 'JOYSOUND詳細取得中', label: 'JOYSOUND詳細の保存が完了しました', detail: nil)
-      message('JOYSOUND詳細を取得しました。')
+      progress&.call(percentage: 96, status: 'JOYSOUND候補追加中', label: 'JOYSOUND候補の保存が完了しました', detail: nil)
+      message('JOYSOUND候補を追加しました。')
     end
 
     def fetch_joysound_music_post_song(progress: nil)
@@ -172,6 +172,7 @@ module Admin
       records = DisplayArtist.where.missing(:songs)
       return message('削除対象のレコードはありませんでした。') if records.empty?
 
+      export_tsv = ActiveModel::Type::Boolean.new.cast(params.dig(:operation_fields, :export_tsv))
       total_count = records.count
       progress&.call(percentage: 8, status: '孤立アーティスト削除中', label: '楽曲が紐づいていないアーティストを削除しています', detail: "処理済み: 0/#{total_count}件", current: 0, total: total_count)
       deleted_records = records.map do |record|
@@ -196,7 +197,9 @@ module Admin
         )
       end
 
-      download(generate_display_artists_tsv(deleted_records), 'deleted_orphan_display_artists.tsv')
+      return download(generate_display_artists_tsv(deleted_records), 'deleted_orphan_display_artists.tsv') if export_tsv
+
+      message("孤立アーティストを削除しました。削除件数: #{deleted_records.size}件。TSVは出力していません。")
     end
 
     def cleanup_expired_joysound_music_posts(progress: nil)

--- a/app/models/admin/resource_registry.rb
+++ b/app/models/admin/resource_registry.rb
@@ -76,7 +76,7 @@ module Admin
       - スマホサービス対応有無
       - 家庭用カラオケ対応有無
 
-      この操作は一覧データ（JoysoundSong）を更新する処理です。Songへの本登録、作曲者による東方判定、曲番号、配信機種などの詳細取得は、別操作の「JOYSOUND楽曲を取得」で行います。
+      この操作は一覧データ（JOYSOUND候補）を更新する処理です。カラオケ楽曲への本登録、作曲者による東方判定、曲番号、配信機種などの詳細取得は、別操作の「JOYSOUND候補をカラオケ楽曲へ登録」で行います。
     TEXT
 
     OPERATION_DESCRIPTIONS = {
@@ -88,7 +88,7 @@ module Admin
       'export_missing_original_songs' => '原曲が未設定の楽曲だけをTSV形式で出力します。原曲紐付け作業の確認・編集用です。',
       'import_songs_with_original_songs' => 'TSVファイルを読み込み、楽曲の原曲紐付けと動画・音楽配信URLを更新します。TSV内の楽曲IDを基準に既存レコードを更新します。',
       'fetch_dam_songs' => <<~TEXT,
-        DAM楽曲一覧に登録済みのURLを巡回し、DAM楽曲詳細をSongとして登録します。既にSongへ登録済みの楽曲はスキップします。
+        DAM楽曲一覧に登録済みのURLを巡回し、DAM楽曲詳細をカラオケ楽曲として登録します。既にカラオケ楽曲へ登録済みの楽曲はスキップします。
 
         参照する外部URL:
         #{Constants::Karaoke::Dam::SONG_URL}
@@ -100,13 +100,13 @@ module Admin
         #{Constants::Karaoke::Dam::SONG_URL}
       TEXT
       'fetch_joysound_songs' => <<~TEXT,
-        JOYSOUND楽曲一覧に登録済みのURLを巡回し、作曲者が東方対象または許可リストに含まれる楽曲をSongとして登録します。曲番号、アーティスト、配信機種も取得します。
+        JOYSOUND楽曲一覧に登録済みのURLを巡回し、作曲者が東方対象または許可リストに含まれる楽曲をカラオケ楽曲として登録します。曲番号、アーティスト、配信機種も取得します。
 
         参照する外部URL:
         #{Constants::Karaoke::Joysound::SEARCH_URL}
       TEXT
       'fetch_joysound_music_post_song' => <<~TEXT,
-        JOYSOUNDミュージックポストの未登録URLや期限間近の楽曲を優先して確認し、うたスキ楽曲としてSongへ登録・更新します。
+        JOYSOUNDミュージックポストの未登録URLや期限間近の楽曲を優先して確認し、うたスキ楽曲としてカラオケ楽曲へ登録・更新します。
 
         参照する外部URL:
         #{Constants::Karaoke::Joysound::SEARCH_URL}
@@ -117,7 +117,7 @@ module Admin
         参照する外部URL:
         #{Constants::Karaoke::Joysound::SEARCH_URL}
       TEXT
-      'update_joysound_music_post_delivery_deadline_dates' => 'JOYSOUNDミュージックポストの配信期限情報を参照し、Songに紐づくうたスキ配信期限を一括更新します。',
+      'update_joysound_music_post_delivery_deadline_dates' => 'JOYSOUNDミュージックポストの配信期限情報を参照し、カラオケ楽曲に紐づくうたスキ配信期限を一括更新します。',
       'fetch_dam_artist' => <<~TEXT,
         DAMアーティストURL一覧を巡回し、DAMアーティストの名前と読みを取得・更新します。読みが未設定のアーティストが対象です。
 
@@ -150,7 +150,7 @@ module Admin
       TEXT
       'cleanup_orphan_display_artists' => '楽曲が1件も紐づいていないアーティストを削除します。削除したアーティストはTSVで出力します。',
       'fetch_dam_touhou_songs' => <<~TEXT,
-        DAMの東方系検索結果を巡回し、DAM楽曲一覧とDAMアーティストURLを登録・更新します。Songへの本登録は別操作の「DAM楽曲を取得」で行います。
+        DAMの東方系検索結果を巡回し、DAM楽曲一覧とDAMアーティストURLを登録・更新します。カラオケ楽曲への本登録は別操作の「DAM候補をカラオケ楽曲へ登録」で行います。
 
         取得元URL:
         #{Constants::Karaoke::Dam::SEARCH_URL}1
@@ -162,7 +162,7 @@ module Admin
         #{Constants::Karaoke::Dam::SONG_URL}
       TEXT
       'fetch_joysound_detail' => <<~TEXT,
-        入力されたJOYSOUND楽曲URLから、表示タイトルを取得してJOYSOUND楽曲一覧へ登録・更新します。詳細なSong登録は「JOYSOUND楽曲を取得」で行います。
+        入力されたJOYSOUND楽曲URLから、表示タイトルを取得してJOYSOUND楽曲一覧へ登録・更新します。詳細なカラオケ楽曲登録は「JOYSOUND候補をカラオケ楽曲へ登録」で行います。
 
         入力URLの形式:
         #{Constants::Karaoke::Joysound::SEARCH_URL}/
@@ -464,12 +464,12 @@ module Admin
             operation('楽曲TSVをエクスポート', handler: :export_songs, group: 'TSV入出力', selection: :required),
             operation('原曲未設定TSVをエクスポート', handler: :export_missing_original_songs, group: 'TSV入出力'),
             operation('原曲付き楽曲TSVをインポート', handler: :import_songs_with_original_songs, group: 'TSV入出力', inputs: [{ name: :tsv_file, label: 'TSVファイル', type: :file, accept: 'text/tab-separated-values' }]),
-            operation('DAM楽曲を取得', method_name: :fetch_dam_songs, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAM楽曲を取得します。実行しますか？'),
-            operation('DAM配信機種を更新', method_name: :update_dam_delivery_models, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAM配信機種を更新します。実行しますか？'),
-            operation('JOYSOUND楽曲を取得', method_name: :fetch_joysound_songs, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUND楽曲を取得します。実行しますか？'),
-            operation('ミュージックポスト楽曲を取得', handler: :fetch_joysound_music_post_song, group: 'ミュージックポスト', async: true, confirmation: '外部サイトへアクセスしてミュージックポスト楽曲を取得します。実行しますか？'),
-            operation('ミュージックポスト楽曲を検証', handler: :refresh_joysound_music_post_song, group: 'ミュージックポスト', async: true, confirmation: '外部サイトへアクセスして無効な楽曲を削除します。実行しますか？'),
-            operation('ミュージックポスト配信期限を更新', handler: :update_joysound_music_post_delivery_deadline_dates, group: 'ミュージックポスト', async: true, confirmation: '配信期限を一括更新します。実行しますか？')
+            operation('DAM候補をカラオケ楽曲へ登録', key: :fetch_dam_songs, method_name: :register_dam_songs_from_candidates, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAM候補をカラオケ楽曲へ登録します。実行しますか？'),
+            operation('DAM配信機種を再同期', key: :update_dam_delivery_models, method_name: :sync_dam_delivery_models, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAM配信機種を再同期します。実行しますか？'),
+            operation('JOYSOUND候補をカラオケ楽曲へ登録', key: :fetch_joysound_songs, method_name: :register_joysound_songs_from_candidates, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUND候補をカラオケ楽曲へ登録します。実行しますか？'),
+            operation('ミュージックポストをカラオケ楽曲へ登録', handler: :fetch_joysound_music_post_song, group: 'ミュージックポスト', async: true, confirmation: '外部サイトへアクセスしてミュージックポストをカラオケ楽曲へ登録します。実行しますか？'),
+            operation('ミュージックポストURLを検証', handler: :refresh_joysound_music_post_song, group: 'ミュージックポスト', async: true, confirmation: '外部サイトへアクセスして無効な楽曲を削除します。実行しますか？'),
+            operation('うたスキ配信期限を反映', handler: :update_joysound_music_post_delivery_deadline_dates, group: 'ミュージックポスト', async: true, confirmation: '配信期限を一括更新します。実行しますか？')
           ],
           strong_parameters: %i[youtube_url nicovideo_url apple_music_url youtube_music_url spotify_url line_music_url]
         )
@@ -499,9 +499,9 @@ module Admin
           ],
           associations: %i[circles songs dam_songs],
           operations: [
-            operation('DAMアーティストを取得', method_name: :fetch_dam_artist, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAMアーティストを取得します。実行しますか？'),
-            operation('JOYSOUNDアーティストを取得', method_name: :fetch_joysound_artist, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUNDアーティストを取得します。実行しますか？'),
-            operation('ミュージックポストアーティストを取得', method_name: :fetch_joysound_music_post_artist, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてミュージックポストアーティストを取得します。実行しますか？'),
+            operation('DAMアーティスト読みを補完', key: :fetch_dam_artist, method_name: :fill_dam_artist_readings, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてDAMアーティスト読みを補完します。実行しますか？'),
+            operation('JOYSOUNDアーティスト読みを補完', key: :fetch_joysound_artist, method_name: :fill_joysound_artist_readings, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUNDアーティスト読みを補完します。実行しますか？'),
+            operation('うたスキアーティストを登録', key: :fetch_joysound_music_post_artist, method_name: :register_joysound_music_post_artists, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてうたスキアーティストを登録します。実行しますか？'),
             operation('URLを検証', handler: :validate_display_artist_urls, group: '検証・削除', confirmation: 'アーティストURLを検証します。実行しますか？'),
             operation('無効なアーティストを削除', handler: :cleanup_invalid_display_artists, group: '検証・削除', confirmation: 'URLが無効なアーティストを削除します。実行しますか？'),
             operation('孤立アーティストを削除', handler: :cleanup_orphan_display_artists, group: '検証・削除', confirmation: '楽曲が紐づいていないアーティストを削除します。実行しますか？')
@@ -529,7 +529,7 @@ module Admin
             field(:url, label: 'URL', type: :url, readonly: true, sortable: true)
           ],
           operations: [
-            operation('東方DAM楽曲を取得', method_name: :fetch_dam_touhou_songs, group: '外部取得', async: true, estimated_seconds: 40, confirmation: '外部サイトへアクセスして東方DAM楽曲を取得します。実行しますか？'),
+            operation('DAM候補一覧を取得', key: :fetch_dam_touhou_songs, method_name: :fetch_dam_candidate_songs, group: '外部取得', async: true, estimated_seconds: 40, confirmation: '外部サイトへアクセスしてDAM候補一覧を取得します。実行しますか？'),
             operation('DAM楽曲を取得', handler: :fetch_dam_song, group: 'URL指定取得', async: true, confirmation: '指定URLからDAM楽曲を取得します。実行しますか？', inputs: [{ name: :dam_song_url, label: 'DAM楽曲URL', type: :text, placeholder: Constants::Karaoke::Dam::SONG_URL }])
           ]
         )
@@ -569,7 +569,7 @@ module Admin
             field(:home_karaoke_enabled, label: '家庭用カラオケ', type: :boolean, readonly: true, sortable: true)
           ],
           operations: [
-            operation('東方JOYSOUND楽曲を取得', method_name: :fetch_joysound_touhou_songs, group: '外部取得', async: true, description: FETCH_JOYSOUND_TOUHOU_SONGS_DESCRIPTION, confirmation: '外部サイトへアクセスして東方JOYSOUND楽曲一覧を取得・更新します。実行しますか？'),
+            operation('JOYSOUND候補一覧を取得', key: :fetch_joysound_touhou_songs, method_name: :fetch_joysound_candidate_songs, group: '外部取得', async: true, description: FETCH_JOYSOUND_TOUHOU_SONGS_DESCRIPTION, confirmation: '外部サイトへアクセスしてJOYSOUND候補一覧を取得・更新します。実行しますか？'),
             operation('JOYSOUND詳細を取得', handler: :fetch_joysound_detail, group: 'URL指定取得', async: true, confirmation: '指定URLからJOYSOUND詳細を取得します。実行しますか？', inputs: [{ name: :joysound_url, label: 'JOYSOUND URL', type: :text }])
           ]
         )
@@ -596,8 +596,8 @@ module Admin
             field(:joysound_url, label: 'JOYSOUND URL', type: :url, index: false, sortable: true)
           ],
           operations: [
-            operation('ミュージックポストを取得', method_name: :fetch_music_post, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてミュージックポストを取得します。実行しますか？'),
-            operation('JOYSOUND URLを取得', method_name: :fetch_music_post_song_joysound_url, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUND URLを取得します。実行しますか？'),
+            operation('ミュージックポスト一覧を取得', key: :fetch_music_post, method_name: :fetch_music_post_entries, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてミュージックポスト一覧を取得します。実行しますか？'),
+            operation('JOYSOUND URLを取得', key: :fetch_music_post_song_joysound_url, method_name: :link_music_posts_to_joysound_urls, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてJOYSOUND URLを取得します。実行しますか？'),
             operation('期限切れを削除', handler: :cleanup_expired_joysound_music_posts, group: '検証・削除', async: true, confirmation: '期限切れのミュージックポストを検証し、無効なレコードを削除します。実行しますか？'),
             operation(
               'フルメンテナンス',

--- a/app/models/admin/resource_registry.rb
+++ b/app/models/admin/resource_registry.rb
@@ -148,7 +148,7 @@ module Admin
         参照する外部URL:
         登録済みの各アーティストURL（DAMまたはJOYSOUNDのアーティストページ）
       TEXT
-      'cleanup_orphan_display_artists' => '楽曲が1件も紐づいていないアーティストを削除します。削除したアーティストはTSVで出力します。',
+      'cleanup_orphan_display_artists' => '楽曲が1件も紐づいていないアーティストを削除します。必要に応じて削除対象をTSVで出力できます。',
       'fetch_dam_touhou_songs' => <<~TEXT,
         DAMの東方系検索結果を巡回し、DAM楽曲一覧とDAMアーティストURLを登録・更新します。カラオケ楽曲への本登録は別操作の「DAM候補をカラオケ楽曲へ登録」で行います。
 
@@ -156,13 +156,13 @@ module Admin
         #{Constants::Karaoke::Dam::SEARCH_URL}1
       TEXT
       'fetch_dam_song' => <<~TEXT,
-        入力されたDAM楽曲URLから、曲名とアーティスト情報を取得し、DAM楽曲一覧へ登録・更新します。
+        入力されたDAM楽曲URLから、曲名とアーティスト情報を取得し、DAM候補一覧へ1件登録・更新します。カラオケ楽曲への本登録は別操作の「DAM候補をカラオケ楽曲へ登録」で行います。
 
         入力URLの形式:
         #{Constants::Karaoke::Dam::SONG_URL}
       TEXT
       'fetch_joysound_detail' => <<~TEXT,
-        入力されたJOYSOUND楽曲URLから、表示タイトルを取得してJOYSOUND楽曲一覧へ登録・更新します。詳細なカラオケ楽曲登録は「JOYSOUND候補をカラオケ楽曲へ登録」で行います。
+        入力されたJOYSOUND楽曲URLから、表示タイトルを取得してJOYSOUND候補一覧へ1件登録・更新します。詳細なカラオケ楽曲登録は「JOYSOUND候補をカラオケ楽曲へ登録」で行います。
 
         入力URLの形式:
         #{Constants::Karaoke::Joysound::SEARCH_URL}/
@@ -504,7 +504,7 @@ module Admin
             operation('うたスキアーティストを登録', key: :fetch_joysound_music_post_artist, method_name: :register_joysound_music_post_artists, group: '外部取得', async: true, confirmation: '外部サイトへアクセスしてうたスキアーティストを登録します。実行しますか？'),
             operation('URLを検証', handler: :validate_display_artist_urls, group: '検証・削除', confirmation: 'アーティストURLを検証します。実行しますか？'),
             operation('無効なアーティストを削除', handler: :cleanup_invalid_display_artists, group: '検証・削除', confirmation: 'URLが無効なアーティストを削除します。実行しますか？'),
-            operation('孤立アーティストを削除', handler: :cleanup_orphan_display_artists, group: '検証・削除', confirmation: '楽曲が紐づいていないアーティストを削除します。実行しますか？')
+            operation('孤立アーティストを削除', handler: :cleanup_orphan_display_artists, group: '検証・削除', confirmation: '楽曲が紐づいていないアーティストを削除します。実行しますか？', inputs: [{ name: :export_tsv, label: '削除結果TSV', description: '削除したアーティストをTSVで出力する', type: :checkbox, checked: true, required: false }])
           ],
           strong_parameters: %i[name_reading url]
         )
@@ -530,7 +530,7 @@ module Admin
           ],
           operations: [
             operation('DAM候補一覧を取得', key: :fetch_dam_touhou_songs, method_name: :fetch_dam_candidate_songs, group: '外部取得', async: true, estimated_seconds: 40, confirmation: '外部サイトへアクセスしてDAM候補一覧を取得します。実行しますか？'),
-            operation('DAM楽曲を取得', handler: :fetch_dam_song, group: 'URL指定取得', async: true, confirmation: '指定URLからDAM楽曲を取得します。実行しますか？', inputs: [{ name: :dam_song_url, label: 'DAM楽曲URL', type: :text, placeholder: Constants::Karaoke::Dam::SONG_URL }])
+            operation('DAM楽曲URLから候補を追加', handler: :fetch_dam_song, group: 'URL指定取得', async: true, confirmation: '指定URLからDAM候補を追加します。実行しますか？', inputs: [{ name: :dam_song_url, label: 'DAM楽曲URL', type: :text, placeholder: Constants::Karaoke::Dam::SONG_URL }])
           ]
         )
       end
@@ -570,7 +570,7 @@ module Admin
           ],
           operations: [
             operation('JOYSOUND候補一覧を取得', key: :fetch_joysound_touhou_songs, method_name: :fetch_joysound_candidate_songs, group: '外部取得', async: true, description: FETCH_JOYSOUND_TOUHOU_SONGS_DESCRIPTION, confirmation: '外部サイトへアクセスしてJOYSOUND候補一覧を取得・更新します。実行しますか？'),
-            operation('JOYSOUND詳細を取得', handler: :fetch_joysound_detail, group: 'URL指定取得', async: true, confirmation: '指定URLからJOYSOUND詳細を取得します。実行しますか？', inputs: [{ name: :joysound_url, label: 'JOYSOUND URL', type: :text }])
+            operation('JOYSOUND楽曲URLから候補を追加', handler: :fetch_joysound_detail, group: 'URL指定取得', async: true, confirmation: '指定URLからJOYSOUND候補を追加します。実行しますか？', inputs: [{ name: :joysound_url, label: 'JOYSOUND楽曲URL', type: :text }])
           ]
         )
       end

--- a/app/models/admin/workflow_definition.rb
+++ b/app/models/admin/workflow_definition.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module Admin
+  class WorkflowDefinition
+    Step = Data.define(:key, :resource_key, :operation_key, :note, :cadence, :kind, :numbered)
+    Branch = Data.define(:key, :label, :steps)
+    Stage = Data.define(:key, :label, :parallel, :branches)
+    Definition = Data.define(:key, :label, :description, :icon, :stages, :metrics)
+
+    class << self
+      def all
+        definitions.index_by(&:key)
+      end
+
+      def fetch(key)
+        all.fetch(key.to_s)
+      end
+
+      def listed
+        definitions.reject { |definition| definition.key == 'full' }
+      end
+
+      def definitions
+        [
+          full_workflow,
+          music_post_workflow,
+          joysound_workflow,
+          dam_workflow,
+          common_workflow
+        ]
+      end
+
+      private
+
+      def full_workflow
+        Definition.new(
+          key: 'full',
+          label: '全体更新',
+          description: 'JOYSOUND(うたスキ)を先に処理し、その後JOYSOUNDとDAMを並列実行します。',
+          icon: :workflow,
+          stages: [
+            Stage.new(key: 'music_post', label: 'JOYSOUND(うたスキ)', parallel: false, branches: [music_post_branch]),
+            Stage.new(key: 'karaoke', label: 'JOYSOUND / DAM', parallel: true, branches: [joysound_branch, dam_branch])
+          ],
+          metrics: []
+        )
+      end
+
+      def music_post_workflow
+        Definition.new(
+          key: 'music_post',
+          label: 'JOYSOUND(うたスキ)',
+          description: 'ミュージックポストの取得、URL紐付け、カラオケ楽曲登録、期限確認をまとめます。',
+          icon: :joysound_music_posts,
+          stages: [Stage.new(key: 'music_post', label: 'JOYSOUND(うたスキ)', parallel: false, branches: [music_post_branch])],
+          metrics: [
+            metric('取得済み', JoysoundMusicPost.count, '件', :admin_joysound_music_posts_path),
+            metric('配信曲', Song.music_post.count, '曲', :admin_songs_path, filters: { karaoke_type: 'joysound_music_post' }),
+            metric('期限切れ', JoysoundMusicPost.where(delivery_deadline_on: ...Date.current).count, '件', :admin_joysound_music_posts_path, filters: { delivery_deadline_on: 'expired' })
+          ]
+        )
+      end
+
+      def joysound_workflow
+        Definition.new(
+          key: 'joysound',
+          label: 'JOYSOUND',
+          description: '候補一覧を作り、カラオケ楽曲登録後にアーティスト読みを補完します。',
+          icon: :joysound_songs,
+          stages: [Stage.new(key: 'joysound', label: 'JOYSOUND', parallel: false, branches: [joysound_branch])],
+          metrics: [
+            metric('JOYSOUND楽曲一覧', JoysoundSong.count, '件', :admin_joysound_songs_path),
+            metric('配信曲', Song.joysound.count, '曲', :admin_songs_path, filters: { karaoke_type: 'joysound' }),
+            metric('家庭用対応', JoysoundSong.where(home_karaoke_enabled: true).count, '件', :admin_joysound_songs_path, filters: { service_enabled: 'home_karaoke' })
+          ]
+        )
+      end
+
+      def dam_workflow
+        Definition.new(
+          key: 'dam',
+          label: 'DAM',
+          description: 'DAM候補一覧を作り、必要ならアーティスト読みを補完してからカラオケ楽曲へ登録します。',
+          icon: :dam_songs,
+          stages: [Stage.new(key: 'dam', label: 'DAM', parallel: false, branches: [dam_branch])],
+          metrics: [
+            metric('DAM楽曲一覧', DamSong.count, '件', :admin_dam_songs_path),
+            metric('配信曲', Song.dam.count, '曲', :admin_songs_path, filters: { karaoke_type: 'dam' }),
+            metric('DAMアーティストURL', DamArtistUrl.count, '件', :admin_dam_artist_urls_path)
+          ]
+        )
+      end
+
+      def common_workflow
+        Definition.new(
+          key: 'common',
+          label: '共通作業',
+          description: '原曲紐付け、TSV入出力、アーティスト整理など配信種別をまたぐ作業です。',
+          icon: :workflow,
+          stages: [Stage.new(key: 'common', label: '共通作業', parallel: false, branches: [common_branch])],
+          metrics: [
+            metric('原曲未紐付け', Song.missing_original_songs.count, '曲', :admin_songs_path, filters: { original_link: 'missing' }),
+            metric('読みなし', DisplayArtist.where(name_reading: [nil, '']).count, '件', :admin_display_artists_path, filters: { name_reading: 'blank' }),
+            metric('孤立アーティスト', DisplayArtist.where.missing(:songs).count, '件', :admin_display_artists_path, filters: { songs: 'blank' })
+          ]
+        )
+      end
+
+      def music_post_branch
+        Branch.new(
+          key: 'music_post',
+          label: 'JOYSOUND(うたスキ)',
+          steps: [
+            step(:joysound_music_post, :fetch_music_post, 'Music Post元データを更新する', cadence: '毎回'),
+            step(:joysound_music_post, :fetch_music_post_song_joysound_url, 'Music PostとJOYSOUND楽曲URLを紐付ける', cadence: '毎回'),
+            step(:display_artist, :fetch_joysound_music_post_artist, '新規アーティストがある時だけ登録・読み補完する', cadence: '新規追加時', kind: :conditional),
+            step(:song, :fetch_joysound_music_post_song, '未登録または期限間近のMusic Postをカラオケ楽曲へ登録・更新する', cadence: '毎回'),
+            step(:song, :refresh_joysound_music_post_song, '登録済みカラオケ楽曲のURL存在確認。削除を伴うので結果確認前提', cadence: '確認時', kind: :check),
+            step(:song, :update_joysound_music_post_delivery_deadline_dates, 'Music Post側の期限をカラオケ楽曲へ反映する', cadence: '期限更新時', kind: :check),
+            step(:joysound_music_post, :perform_full_joysound_music_post_maintenance, '手順4〜6と期限切れ整理をまとめて行う保守用。手順1〜3の代替ではない', cadence: '保守まとめ', kind: :maintenance, numbered: false)
+          ]
+        )
+      end
+
+      def joysound_branch
+        Branch.new(
+          key: 'joysound',
+          label: 'JOYSOUND',
+          steps: [
+            step(:joysound_song, :fetch_joysound_touhou_songs, 'JOYSOUND東方系の候補一覧を更新する', cadence: '毎回'),
+            step(:song, :fetch_joysound_songs, '候補一覧から東方対象を判定してカラオケ楽曲へ登録する', cadence: '毎回'),
+            step(:display_artist, :fetch_joysound_artist, 'カラオケ楽曲登録で作られた新規アーティストの読みを補完する', cadence: '新規追加時', kind: :conditional)
+          ]
+        )
+      end
+
+      def dam_branch
+        Branch.new(
+          key: 'dam',
+          label: 'DAM',
+          steps: [
+            step(:dam_song, :fetch_dam_touhou_songs, 'DAM候補一覧とDAMアーティストURLを作る。通常1回、件数が不自然なら再実行', cadence: '毎回'),
+            step(:display_artist, :fetch_dam_artist, '新規アーティストURLがある時だけ読みを補完する', cadence: '新規追加時', kind: :conditional),
+            step(:song, :fetch_dam_songs, 'DAM候補一覧の詳細をカラオケ楽曲へ登録する', cadence: '毎回'),
+            step(:song, :update_dam_delivery_models, '新しいDAM配信機種が増えた時だけ再同期する', cadence: '低頻度', kind: :maintenance, numbered: false)
+          ]
+        )
+      end
+
+      def common_branch
+        Branch.new(
+          key: 'common',
+          label: '共通作業',
+          steps: [
+            step(:song, :export_missing_original_songs, 'カラオケ楽曲登録後に原曲未設定だけを抽出する'),
+            step(:song, :import_songs_with_original_songs, '編集済みTSVで原曲紐付けと配信URLを反映する', kind: :conditional),
+            step(:song, :export_songs, '確認・外部反映用に現在の楽曲TSVを出力する', kind: :conditional),
+            step(:display_artist, :validate_display_artist_urls, '削除前に無効URLを確認する', kind: :check),
+            step(:display_artist, :cleanup_orphan_display_artists, '楽曲に紐づかないアーティストを整理する', kind: :maintenance)
+          ]
+        )
+      end
+
+      def step(resource_key, operation_key, note, **options)
+        Step.new(
+          key: "#{resource_key}:#{operation_key}",
+          resource_key: resource_key.to_s,
+          operation_key: operation_key.to_s,
+          note:,
+          cadence: options.fetch(:cadence, '必要時'),
+          kind: options.fetch(:kind, :main).to_s,
+          numbered: options.fetch(:numbered, true)
+        )
+      end
+
+      def metric(label, value, unit, route_name, **route_options)
+        { label:, value:, unit:, route_name:, route_options: }
+      end
+    end
+  end
+end

--- a/app/models/admin/workflow_definition.rb
+++ b/app/models/admin/workflow_definition.rb
@@ -20,6 +20,10 @@ module Admin
         definitions.reject { |definition| definition.key == 'full' }
       end
 
+      def operation_pair?(resource_key, operation_key)
+        operation_pairs.include?([resource_key.to_s, operation_key.to_s])
+      end
+
       def definitions
         [
           full_workflow,
@@ -31,6 +35,17 @@ module Admin
       end
 
       private
+
+      def operation_pairs
+        [
+          music_post_branch,
+          joysound_branch,
+          dam_branch,
+          common_branch
+        ].flat_map do |branch|
+          branch.steps.map { |step| [step.resource_key, step.operation_key] }
+        end.uniq
+      end
 
       def full_workflow
         Definition.new(
@@ -128,6 +143,7 @@ module Admin
           label: 'JOYSOUND',
           steps: [
             step(:joysound_song, :fetch_joysound_touhou_songs, 'JOYSOUND東方系の候補一覧を更新する', cadence: '毎回'),
+            step(:joysound_song, :fetch_joysound_detail, 'URLを直接指定してJOYSOUND候補を1件追加・更新する', cadence: '任意', kind: :optional, numbered: false),
             step(:song, :fetch_joysound_songs, '候補一覧から東方対象を判定してカラオケ楽曲へ登録する', cadence: '毎回'),
             step(:display_artist, :fetch_joysound_artist, 'カラオケ楽曲登録で作られた新規アーティストの読みを補完する', cadence: '新規追加時', kind: :conditional)
           ]
@@ -140,6 +156,7 @@ module Admin
           label: 'DAM',
           steps: [
             step(:dam_song, :fetch_dam_touhou_songs, 'DAM候補一覧とDAMアーティストURLを作る。通常1回、件数が不自然なら再実行', cadence: '毎回'),
+            step(:dam_song, :fetch_dam_song, 'URLを直接指定してDAM候補を1件追加・更新する', cadence: '任意', kind: :optional, numbered: false),
             step(:display_artist, :fetch_dam_artist, '新規アーティストURLがある時だけ読みを補完する', cadence: '新規追加時', kind: :conditional),
             step(:song, :fetch_dam_songs, 'DAM候補一覧の詳細をカラオケ楽曲へ登録する', cadence: '毎回'),
             step(:song, :update_dam_delivery_models, '新しいDAM配信機種が増えた時だけ再同期する', cadence: '低頻度', kind: :maintenance, numbered: false)
@@ -152,11 +169,11 @@ module Admin
           key: 'common',
           label: '共通作業',
           steps: [
-            step(:song, :export_missing_original_songs, 'カラオケ楽曲登録後に原曲未設定だけを抽出する'),
-            step(:song, :import_songs_with_original_songs, '編集済みTSVで原曲紐付けと配信URLを反映する', kind: :conditional),
-            step(:song, :export_songs, '確認・外部反映用に現在の楽曲TSVを出力する', kind: :conditional),
-            step(:display_artist, :validate_display_artist_urls, '削除前に無効URLを確認する', kind: :check),
-            step(:display_artist, :cleanup_orphan_display_artists, '楽曲に紐づかないアーティストを整理する', kind: :maintenance)
+            step(:song, :export_missing_original_songs, 'カラオケ楽曲登録後に原曲未設定だけを抽出する', numbered: false),
+            step(:song, :import_songs_with_original_songs, '編集済みTSVで原曲紐付けと配信URLを反映する', kind: :conditional, numbered: false),
+            step(:song, :export_songs, '確認・外部反映用に現在の楽曲TSVを出力する', kind: :conditional, numbered: false),
+            step(:display_artist, :validate_display_artist_urls, '削除前に無効URLを確認する', kind: :check, numbered: false),
+            step(:display_artist, :cleanup_orphan_display_artists, '楽曲に紐づかないアーティストを整理する', kind: :maintenance, numbered: false)
           ]
         )
       end

--- a/app/models/admin/workflow_run_progress.rb
+++ b/app/models/admin/workflow_run_progress.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module Admin
+  class WorkflowRunProgress
+    ACTIVE_STATES = %w[queued running].freeze
+
+    class << self
+      def create!(id, workflow:)
+        OperationProgress.enqueue!(id, label: "#{workflow.label}を開始待ちです")
+        OperationProgress.update!(id, status: 'ジョブ待機中')
+        update_detail!(id) { build_payload(workflow) }
+      end
+
+      def read(id)
+        progress = OperationProgress.read(id)
+        workflow = detail_payload(progress[:detail])
+        workflow[:steps]&.each do |step|
+          step[:progress] = OperationProgress.read(step[:progress_id]) if step[:progress_id].present?
+        end
+        workflow[:current_step] = current_step_payload(workflow[:steps])
+        progress[:percentage] = workflow_percentage(progress, workflow)
+        progress.merge(workflow:)
+      end
+
+      def active_conflict_for(workflow)
+        target_steps = executable_step_signatures(workflow)
+        active_records.find do |record|
+          payload = detail_payload(record.detail)
+          next false if payload[:workflow_key].blank?
+
+          executable_step_signatures_from_payload(payload).intersect?(target_steps)
+        end
+      end
+
+      def start!(id, workflow:)
+        OperationProgress.update!(id, state: 'running', percentage: 0, status: '開始待ち', label: "#{workflow.label}を実行しています")
+      end
+
+      def complete!(id, workflow:)
+        OperationProgress.update!(id, state: 'completed', percentage: 100, status: '完了', label: "#{workflow.label}が完了しました")
+      end
+
+      def fail!(id, message:)
+        OperationProgress.update!(id, state: 'failed', status: 'エラー', label: "処理中にエラーが発生しました: #{message}")
+      end
+
+      def mark_step!(id, step_key, status:, progress_id: nil, error: nil)
+        update_detail!(id) do |payload|
+          step = payload[:steps].find { |item| item[:key] == step_key }
+          if step
+            step[:status] = status
+            step[:progress_id] = progress_id if progress_id
+            step[:error] = error if error
+          end
+          payload[:completed_steps] = payload[:steps].count { |item| item[:status] == 'completed' }
+          payload[:failed_steps] = payload[:steps].count { |item| item[:status] == 'failed' }
+          payload
+        end
+        update_parent_percentage!(id)
+      end
+
+      def update_stage!(id, label:)
+        OperationProgress.update!(id, status: '実行中', label:)
+      end
+
+      private
+
+      def active_records
+        OperationProgress::Record
+          .where(state: ACTIVE_STATES)
+          .where(updated_at: OperationProgress::CACHE_TTL.ago..)
+          .order(updated_at: :desc)
+      end
+
+      def build_payload(workflow)
+        steps = workflow.stages.flat_map.with_index do |stage, stage_index|
+          stage.branches.flat_map do |branch|
+            branch.steps.map.with_index do |step, step_index|
+              resource = ResourceRegistry.fetch(step.resource_key)
+              operation = resource.operations.find { |item| item.key == step.operation_key }
+              {
+                key: "#{stage.key}:#{branch.key}:#{step.key}",
+                stage_key: stage.key,
+                stage_label: stage.label,
+                branch_key: branch.key,
+                branch_label: branch.label,
+                stage_index:,
+                step_index:,
+                resource_key: step.resource_key,
+                operation_key: step.operation_key,
+                label: operation&.label || step.operation_key,
+                note: step.note,
+                status: step.numbered ? 'pending' : 'manual',
+                progress_id: nil,
+                error: nil
+              }
+            end
+          end
+        end
+
+        {
+          workflow_key: workflow.key,
+          workflow_label: workflow.label,
+          total_steps: steps.count { |step| step[:status] != 'manual' },
+          completed_steps: 0,
+          failed_steps: 0,
+          steps:
+        }
+      end
+
+      def executable_step_signatures(workflow)
+        workflow.stages.flat_map do |stage|
+          stage.branches.flat_map do |branch|
+            branch.steps.select(&:numbered).map { |step| "#{step.resource_key}:#{step.operation_key}" }
+          end
+        end
+      end
+
+      def executable_step_signatures_from_payload(payload)
+        payload.fetch(:steps, []).filter_map do |step|
+          "#{step[:resource_key]}:#{step[:operation_key]}" if step[:status] != 'manual'
+        end
+      end
+
+      def current_step_payload(steps)
+        return nil if steps.blank?
+
+        current = steps.find { |step| step[:status] == 'running' } ||
+                  steps.find { |step| step[:status] == 'failed' } ||
+                  steps.find { |step| step[:status] == 'pending' }
+        return nil unless current
+
+        current.slice(:key, :label, :stage_label, :branch_label, :status, :progress)
+      end
+
+      def workflow_percentage(progress, workflow)
+        return 100 if progress[:state] == 'completed'
+
+        total = workflow[:total_steps].to_i
+        return progress[:percentage].to_i.clamp(0, 100) unless total.positive?
+
+        completed = workflow[:completed_steps].to_i
+        running = workflow.fetch(:steps, []).find { |step| step[:status] == 'running' }
+        running_ratio = running ? (running.dig(:progress, :percentage).to_i.clamp(0, 100) / 100.0) : 0
+        (((completed + running_ratio) / total) * 100).floor.clamp(0, progress[:state] == 'failed' ? 100 : 99)
+      end
+
+      def update_parent_percentage!(id)
+        payload = detail_payload(OperationProgress.read(id)[:detail])
+        total = payload[:total_steps].to_i
+        completed = payload[:completed_steps].to_i
+        percentage = total.positive? ? ((completed.to_f / total) * 100).floor.clamp(0, 99) : 0
+        OperationProgress.update!(id, percentage:, current: completed, total:)
+      end
+
+      def update_detail!(id)
+        record = OperationProgress::Record.find(id)
+        record.with_lock do
+          payload = yield(detail_payload(record.detail))
+          record.update!(detail: JSON.generate(payload.deep_stringify_keys))
+          Rails.cache.write("admin:operation_progress:#{id}", OperationProgress.read(id).merge(detail: record.detail), expires_in: OperationProgress::CACHE_TTL)
+        end
+      end
+
+      def detail_payload(detail)
+        return {} if detail.blank?
+
+        JSON.parse(detail).deep_symbolize_keys
+      rescue JSON::ParserError
+        {}
+      end
+    end
+  end
+end

--- a/app/models/dam_artist_url.rb
+++ b/app/models/dam_artist_url.rb
@@ -29,6 +29,10 @@ class DamArtistUrl < ApplicationRecord
     end
   end
 
+  def self.fill_dam_artist_readings(progress: nil)
+    fetch_dam_artist(progress:)
+  end
+
   def self.dam_artist_page_parser(url)
     retry_count = 0
     @browser = Ferrum::Browser.new(timeout: 10, window_size: [1440, 900], browser_options: { 'no-sandbox': nil })

--- a/app/models/dam_song.rb
+++ b/app/models/dam_song.rb
@@ -112,6 +112,10 @@ class DamSong < ApplicationRecord
     end
   end
 
+  def self.fetch_dam_candidate_songs(progress: nil)
+    fetch_dam_touhou_songs(progress:)
+  end
+
   def self.detect_dam_search_total_pages(browser, page_size)
     pages_from_links = browser.css('a[href*="pageNo="]').filter_map do |link|
       link.attribute('href').to_s[/pageNo=(\d+)/, 1]&.to_i

--- a/app/models/display_artist.rb
+++ b/app/models/display_artist.rb
@@ -49,6 +49,10 @@ class DisplayArtist < ApplicationRecord
     end
   end
 
+  def self.fill_joysound_artist_readings(progress: nil)
+    fetch_joysound_artist(progress:)
+  end
+
   def self.fetch_joysound_music_post_artist(progress: nil)
     url = Constants::Karaoke::Joysound::BASE_URL
     browser = Ferrum::Browser.new(timeout: 10, window_size: [1440, 2000], browser_options: { 'no-sandbox': nil })
@@ -130,6 +134,10 @@ class DisplayArtist < ApplicationRecord
       )
     end
     logger.debug("未登録アーティスト：#{error_artist}") if error_artist.present?
+  end
+
+  def self.register_joysound_music_post_artists(progress: nil)
+    fetch_joysound_music_post_artist(progress:)
   end
 
   def self.progress_percentage(current, total)

--- a/app/models/display_artist.rb
+++ b/app/models/display_artist.rb
@@ -53,6 +53,10 @@ class DisplayArtist < ApplicationRecord
     fetch_joysound_artist(progress:)
   end
 
+  def self.fill_dam_artist_readings(progress: nil)
+    DamArtistUrl.fill_dam_artist_readings(progress:)
+  end
+
   def self.fetch_joysound_music_post_artist(progress: nil)
     url = Constants::Karaoke::Joysound::BASE_URL
     browser = Ferrum::Browser.new(timeout: 10, window_size: [1440, 2000], browser_options: { 'no-sandbox': nil })

--- a/app/models/joysound_music_post.rb
+++ b/app/models/joysound_music_post.rb
@@ -17,6 +17,10 @@ class JoysoundMusicPost < ApplicationRecord
     music_post_parser(url_u2, progress:, progress_range: 52..96, label: "あきやまうに楽曲のミュージックポストを取得しています")
   end
 
+  def self.fetch_music_post_entries(progress: nil)
+    fetch_music_post(progress:)
+  end
+
   def self.fetch_music_post_song_joysound_url(progress: nil)
     browser = Ferrum::Browser.new(timeout: 10, window_size: [1440, 2000], browser_options: { 'no-sandbox': nil })
     search_option = "?sortOrder=new&orderBy=desc&startIndex=0#songlist"
@@ -71,6 +75,10 @@ class JoysoundMusicPost < ApplicationRecord
   rescue StandardError => e
     logger.error(e)
     browser.screenshot(path: "tmp/music_post.png")
+  end
+
+  def self.link_music_posts_to_joysound_urls(progress: nil)
+    fetch_music_post_song_joysound_url(progress:)
   end
 
   def self.music_post_parser(url, progress: nil, progress_range: 8..96, label: "ミュージックポストを取得しています")

--- a/app/models/joysound_song.rb
+++ b/app/models/joysound_song.rb
@@ -100,6 +100,10 @@ class JoysoundSong < ApplicationRecord
     end
   end
 
+  def self.fetch_joysound_candidate_songs(progress: nil)
+    fetch_joysound_touhou_songs(progress:)
+  end
+
   def self.fetch_joysound_song_direct(url: nil)
     browser = Ferrum::Browser.new(timeout: 30, window_size: [1440, 900], browser_options: { 'no-sandbox': nil })
     begin

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -88,6 +88,10 @@ class Song < ApplicationRecord
     end
   end
 
+  def self.register_joysound_songs_from_candidates(progress: nil)
+    fetch_joysound_songs(progress:)
+  end
+
   def self.fetch_joysound_music_post_song
     scraper = Scrapers::JoysoundScraper.new
 
@@ -98,6 +102,10 @@ class Song < ApplicationRecord
     process_with_progress(prioritized_posts, label: "JOYSOUND Music Posts") do |record|
       scraper.scrape_music_post_page(record)
     end
+  end
+
+  def self.register_joysound_music_post_songs
+    fetch_joysound_music_post_song
   end
 
   def self.prioritized_joysound_music_posts
@@ -134,6 +142,10 @@ class Song < ApplicationRecord
     end
   end
 
+  def self.verify_joysound_music_post_songs
+    refresh_joysound_music_post_song
+  end
+
   def self.fetch_dam_songs(progress: nil)
     scraper = Scrapers::DamScraper.new
     dam_songs = DamSong.order(created_at: :desc)
@@ -147,6 +159,10 @@ class Song < ApplicationRecord
     end
   end
 
+  def self.register_dam_songs_from_candidates(progress: nil)
+    fetch_dam_songs(progress:)
+  end
+
   def self.update_dam_delivery_models(progress: nil)
     scraper = Scrapers::DamScraper.new
     dam_songs = Song.dam.includes(:karaoke_delivery_models)
@@ -155,6 +171,10 @@ class Song < ApplicationRecord
     process_with_progress(dam_songs, label: "Update DAM Delivery Models", progress:, progress_options: { status: "DAM配信機種更新中", label: "DAM配信機種を更新しています" }) do |song|
       scraper.update_delivery_models(song)
     end
+  end
+
+  def self.sync_dam_delivery_models(progress: nil)
+    update_dam_delivery_models(progress:)
   end
 
   def self.update_joysound_music_post_delivery_deadline_dates
@@ -179,5 +199,9 @@ class Song < ApplicationRecord
     end
 
     logger.info("Updated #{updated_count} songs out of #{total_count} total music post songs")
+  end
+
+  def self.sync_joysound_music_post_delivery_deadlines
+    update_joysound_music_post_delivery_deadline_dates
   end
 end

--- a/app/views/admin/resources/_operation_form.html.erb
+++ b/app/views/admin/resources/_operation_form.html.erb
@@ -1,7 +1,8 @@
 <% modal = local_assigns.fetch(:modal, false) %>
 <% supports_selection = record.blank? && operation.selection != :none %>
 <% selection_required = operation.selection == :required %>
-<% submit_disabled = selection_required || operation.inputs.present? %>
+<% required_inputs = operation.inputs.select { |input| input.fetch(:required, true) } %>
+<% submit_disabled = selection_required || required_inputs.present? %>
 <% operation_progress_id = SecureRandom.uuid %>
 <%= form_with url: admin_operation_path(resource, record, operation.key), method: :post, multipart: operation.inputs.any? { |input| input[:type] == :file }, class: "admin-form", data: { admin_operation_form: true, confirmation: operation.confirmation.presence || "#{operation.label}を実行します。よろしいですか？", admin_operation_action: operation.action_key, admin_operation_async: operation.async, admin_operation_estimated_seconds: operation.estimated_seconds, admin_operation_progress_url: admin_operation_progress_path(resource, record, operation.key, operation_progress_id), admin_operation_inline_confirmation: modal, admin_operation_selection: supports_selection, admin_operation_selection_required: selection_required } do |form| %>
   <%= hidden_field_tag :operation_progress_id, operation_progress_id %>
@@ -18,6 +19,12 @@
       <%= form.label "operation_fields_#{input[:name]}", input[:label] %>
       <% if input[:type] == :file %>
         <%= file_field_tag "operation_fields[#{input[:name]}]", accept: input[:accept], id: "operation_fields_#{input[:name]}", class: "file-input file-input-bordered w-full", required: true, data: { admin_operation_required_input: true } %>
+      <% elsif input[:type] == :checkbox %>
+        <label class="admin-checkbox-field">
+          <%= hidden_field_tag "operation_fields[#{input[:name]}]", "0", id: nil %>
+          <%= check_box_tag "operation_fields[#{input[:name]}]", "1", input.fetch(:checked, false), id: "operation_fields_#{input[:name]}", class: "checkbox checkbox-sm" %>
+          <span><%= input[:description].presence || input[:label] %></span>
+        </label>
       <% else %>
         <%= text_field_tag "operation_fields[#{input[:name]}]", nil, id: "operation_fields_#{input[:name]}", placeholder: input[:placeholder], class: "admin-input input input-bordered w-full", required: true, data: { admin_operation_required_input: true } %>
       <% end %>

--- a/app/views/admin/resources/_operation_modal.html.erb
+++ b/app/views/admin/resources/_operation_modal.html.erb
@@ -1,6 +1,6 @@
 <% modal_operations = operations.select { |operation| operation.scope == :collection } %>
 <% if modal_operations.present? %>
-  <dialog class="modal admin-operation-modal" data-admin-operation-modal>
+  <dialog class="modal admin-operation-modal" data-admin-operation-modal data-admin-operation-resource="<%= resource.key %>">
     <div class="modal-box admin-operation-modal-box">
       <div class="admin-operation-modal-header">
         <div>
@@ -13,7 +13,7 @@
       <% modal_operations.each do |operation| %>
         <section class="admin-operation-modal-panel" data-admin-operation-panel="<%= operation.key %>" <%= "hidden" unless operation == modal_operations.first %>>
           <div class="admin-operation-description"><%= linked_operation_description(operation.description) %></div>
-          <%= render "operation_form", resource:, record: nil, operation:, modal: true %>
+          <%= render "admin/resources/operation_form", resource:, record: nil, operation:, modal: true %>
         </section>
       <% end %>
     </div>

--- a/app/views/admin/resources/_operations.html.erb
+++ b/app/views/admin/resources/_operations.html.erb
@@ -1,5 +1,5 @@
 <% operation_scope = record.present? ? :member : :collection %>
-<% available_operations = resource.operations.each_with_index.select { |operation, _index| operation.scope == operation_scope } %>
+<% available_operations = resource.operations.each_with_index.select { |operation, _index| operation.scope == operation_scope && admin_resource_operation_visible?(resource, operation, operation_scope) } %>
 <% if available_operations.present? %>
   <% if operation_scope == :collection %>
     <details class="admin-operation-guide admin-control-panel" aria-labelledby="admin-operation-guide-<%= resource.key %>">

--- a/app/views/admin/resources/_operations.html.erb
+++ b/app/views/admin/resources/_operations.html.erb
@@ -2,31 +2,43 @@
 <% available_operations = resource.operations.each_with_index.select { |operation, _index| operation.scope == operation_scope } %>
 <% if available_operations.present? %>
   <% if operation_scope == :collection %>
-    <div class="admin-operation-dropdown-wrap admin-control-panel">
-      <span class="admin-display-settings-title">操作</span>
-      <details class="admin-operation-dropdown dropdown dropdown-end">
-        <summary class="admin-button admin-operation-dropdown-button btn">
-          <%= admin_icon(:action) %>
-          <span>操作を選択</span>
-          <%= admin_icon(:disclosure, class: "admin-operation-dropdown-caret") %>
-        </summary>
-        <div class="admin-operation-dropdown-menu dropdown-content menu">
-          <% available_operations.group_by { |operation, _index| operation.group }.each do |group, operations| %>
-            <section class="admin-operation-dropdown-group">
-              <h3><%= group %></h3>
-              <div class="admin-operation-dropdown-list">
-                <% operations.each do |operation, _index| %>
-                  <%= link_to admin_operation_path(resource, record, operation.key), class: "admin-operation-dropdown-item", data: { admin_operation_trigger: true, admin_operation_key: operation.key } do %>
-                    <%= admin_icon(:action) %>
-                    <span><%= operation.label %></span>
-                  <% end %>
-                <% end %>
-              </div>
-            </section>
-          <% end %>
+    <details class="admin-operation-guide admin-control-panel" aria-labelledby="admin-operation-guide-<%= resource.key %>">
+      <summary class="admin-operation-guide-summary">
+        <div>
+          <span class="admin-operation-guide-kicker"><%= resource.label %></span>
+          <h2 id="admin-operation-guide-<%= resource.key %>">運用アクション</h2>
         </div>
-      </details>
-    </div>
+        <span>開く</span>
+      </summary>
+
+      <div class="admin-operation-guide-groups">
+        <% available_operations.group_by { |operation, _index| operation.group }.each do |group, operations| %>
+          <section class="admin-operation-guide-group">
+            <h3><%= group %></h3>
+            <div class="admin-operation-guide-list">
+              <% operations.each do |operation, _index| %>
+                <%= link_to admin_operation_path(resource, record, operation.key), class: "admin-operation-guide-item", data: { admin_operation_trigger: true, admin_operation_resource: resource.key, admin_operation_key: operation.key, admin_operation_label: operation.label } do %>
+                  <span class="admin-operation-guide-icon"><%= admin_icon(operation.inputs.any? { |input| input[:type] == :file } ? :upload : :action) %></span>
+                  <span class="admin-operation-guide-body">
+                    <strong><%= operation.label %></strong>
+                    <span><%= admin_operation_summary(operation) %></span>
+                    <span class="admin-operation-guide-meta">
+                      <% admin_operation_status_labels(operation).each do |label| %>
+                        <small><%= label %></small>
+                      <% end %>
+                    </span>
+                  </span>
+                  <span class="admin-operation-guide-cta">
+                    <%= admin_operation_cta(operation) %>
+                    <%= admin_icon(:next) %>
+                  </span>
+                <% end %>
+              <% end %>
+            </div>
+          </section>
+        <% end %>
+      </div>
+    </details>
   <% else %>
     <section class="admin-panel admin-operations">
       <div class="admin-operations-heading">

--- a/app/views/admin/resources/index.html.erb
+++ b/app/views/admin/resources/index.html.erb
@@ -13,6 +13,8 @@
   <% end %>
 </header>
 
+<%= render "operations", resource: @resource, record: nil %>
+
 <div class="admin-index-toolbar">
   <%= form_with url: admin_resources_path(@resource), method: :get, class: "admin-query-panel admin-control-panel", data: { admin_filter_form: true } do |form| %>
     <%= form.hidden_field :view_mode, value: @view_mode %>
@@ -56,10 +58,6 @@
       </details>
     <% end %>
   <% end %>
-
-  <div class="admin-toolbar-side">
-    <%= render "operations", resource: @resource, record: nil %>
-  </div>
 </div>
 
 <div class="admin-table-controls">

--- a/app/views/admin/workflow/index.html.erb
+++ b/app/views/admin/workflow/index.html.erb
@@ -1,0 +1,93 @@
+<header class="admin-page-header">
+  <div>
+    <h1>運用フロー</h1>
+    <p>配信種別ごとに、操作内容から推定した実行順で整理しています</p>
+  </div>
+  <%= link_to admin_workflow_steps_path("full"), class: "admin-button admin-button-primary btn btn-primary" do %>
+    <%= admin_icon(:workflow) %>
+    <span>全体更新を開く</span>
+  <% end %>
+</header>
+
+<section class="admin-workflow-route admin-panel" aria-labelledby="admin-workflow-route">
+  <div class="admin-section-heading">
+    <h2 id="admin-workflow-route">推奨実行順</h2>
+    <p>全体更新時の基本順です。DAMのみ、JOYSOUND(うたスキ)のみの運用もできます。</p>
+  </div>
+  <ol class="admin-workflow-route-list">
+    <% @workflow_order.each_with_index do |label, index| %>
+      <li>
+        <span><%= index + 1 %></span>
+        <strong><%= label %></strong>
+      </li>
+    <% end %>
+  </ol>
+</section>
+
+<section class="admin-workflow-note admin-panel" aria-labelledby="admin-workflow-note">
+  <div class="admin-section-heading">
+    <h2 id="admin-workflow-note">運用メモ</h2>
+    <p>実装確認とヒアリング内容を反映した並びです。</p>
+  </div>
+  <ul class="admin-workflow-question-list">
+    <% @workflow_notes.each do |note| %>
+      <li><%= note %></li>
+    <% end %>
+  </ul>
+</section>
+
+<div class="admin-workflow-groups">
+  <% @workflow_groups.each do |group| %>
+    <section class="admin-workflow-group">
+      <header>
+        <span class="admin-workflow-group-icon"><%= admin_icon(group[:icon]) %></span>
+        <div>
+          <h2><%= group[:label] %></h2>
+          <p><%= group[:description] %></p>
+        </div>
+        <% unless group[:key] == "common" %>
+          <%= link_to admin_workflow_steps_path(group[:key]), class: "admin-workflow-run-link" do %>
+            <span>ステップ実行</span>
+            <%= admin_icon(:next) %>
+          <% end %>
+        <% end %>
+      </header>
+
+      <div class="admin-workflow-actions">
+        <% step_number = 0 %>
+        <% group[:actions].each do |action| %>
+          <% step_number += 1 if action[:numbered] %>
+          <% action_classes = ["admin-workflow-action", "admin-workflow-action-#{action[:kind]}"] %>
+          <%= button_tag type: :button, class: action_classes.join(" "), data: { admin_operation_trigger: true, admin_operation_resource: action[:resource].key, admin_operation_key: action[:operation].key, admin_operation_label: action[:operation].label } do %>
+            <span class="admin-workflow-action-number"><%= action[:numbered] ? step_number : "任意" %></span>
+            <span class="admin-workflow-action-body">
+              <span><%= action[:resource].label %></span>
+              <strong><%= action[:operation].label %></strong>
+              <small><%= action[:note] %></small>
+              <span class="admin-workflow-action-tags">
+                <%= action[:cadence] %>
+                <%= " / " %>
+                <%= admin_operation_status_labels(action[:operation]).join(" / ") %>
+              </span>
+            </span>
+            <%= admin_icon(:next) %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="admin-workflow-metrics">
+        <% group[:metrics].each do |metric| %>
+          <%= link_to metric[:path], class: "admin-workflow-metric" do %>
+            <span><%= metric[:label] %></span>
+            <strong><%= number_with_delimiter(metric[:value]) %></strong>
+            <small><%= metric[:unit] %></small>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+</div>
+
+<% @workflow_operation_resources.each do |resource| %>
+  <%= render "admin/resources/operation_modal", resource:, operations: resource.operations %>
+<% end %>

--- a/app/views/admin/workflow/index.html.erb
+++ b/app/views/admin/workflow/index.html.erb
@@ -58,6 +58,7 @@
         <% group[:actions].each do |action| %>
           <% step_number += 1 if action[:numbered] %>
           <% action_classes = ["admin-workflow-action", "admin-workflow-action-#{action[:kind]}"] %>
+          <% action_classes << "admin-workflow-action-manual" unless action[:numbered] %>
           <%= button_tag type: :button, class: action_classes.join(" "), data: { admin_operation_trigger: true, admin_operation_resource: action[:resource].key, admin_operation_key: action[:operation].key, admin_operation_label: action[:operation].label } do %>
             <span class="admin-workflow-action-number"><%= action[:numbered] ? step_number : "任意" %></span>
             <span class="admin-workflow-action-body">

--- a/app/views/admin/workflow/show.html.erb
+++ b/app/views/admin/workflow/show.html.erb
@@ -1,0 +1,135 @@
+<header class="admin-page-header">
+  <div>
+    <h1><%= @workflow.label %></h1>
+    <p><%= @workflow.description %></p>
+  </div>
+  <div class="admin-workflow-header-actions">
+    <%= link_to admin_workflow_path, class: "admin-button btn btn-ghost" do %>
+      <%= admin_icon(:back) %>
+      <span>フロー一覧</span>
+    <% end %>
+    <% unless @workflow.key == "common" %>
+      <% run_blocked = @active_workflow_run.present? %>
+      <%= button_to admin_run_workflow_path(@workflow.key), method: :post, class: "admin-button admin-button-primary btn btn-primary", disabled: run_blocked, data: { turbo: false } do %>
+        <%= admin_icon(:action) %>
+        <span><%= run_blocked ? "自動実行中" : "自動実行を開始" %></span>
+      <% end %>
+    <% end %>
+  </div>
+</header>
+
+<% workflow_steps_by_key = (@workflow_run&.dig(:workflow, :steps) || []).index_by { |step| step[:key] } %>
+<% current_step = @workflow_run&.dig(:workflow, :current_step) %>
+
+<% if @active_workflow_run.present? && @active_workflow_run[:workflow_key] != @workflow.key %>
+  <section class="admin-workflow-status admin-panel">
+    <div class="admin-section-heading">
+      <h2>実行状況</h2>
+      <p><%= @active_workflow_run[:workflow_label] %>を実行中です。重複実行を避けるため、このフローの自動実行は開始できません。</p>
+    </div>
+    <%= link_to admin_workflow_steps_path(@active_workflow_run[:workflow_key], run_id: @active_workflow_run[:id]), class: "admin-button btn btn-outline" do %>
+      <%= admin_icon(:workflow) %>
+      <span>実行中の状況を見る</span>
+    <% end %>
+  </section>
+<% elsif @workflow_run.present? %>
+  <section class="admin-workflow-status admin-panel" data-admin-workflow-status>
+    <div class="admin-section-heading">
+      <h2>実行状況</h2>
+      <p data-admin-workflow-status-label><%= @workflow_run[:label] %></p>
+    </div>
+    <div class="admin-workflow-status-grid">
+      <div>
+        <span>状態</span>
+        <strong data-admin-workflow-status-state><%= @workflow_run[:status] %></strong>
+      </div>
+      <div>
+        <span>進捗</span>
+        <strong data-admin-workflow-status-percent><%= @workflow_run[:percentage] %>%</strong>
+      </div>
+      <div>
+        <span>現在のステップ</span>
+        <strong data-admin-workflow-status-current><%= current_step&.dig(:label) || "完了" %></strong>
+      </div>
+      <div>
+        <span>完了ステップ</span>
+        <strong data-admin-workflow-status-count><%= @workflow_run.dig(:workflow, :completed_steps).to_i %> / <%= @workflow_run.dig(:workflow, :total_steps).to_i %></strong>
+      </div>
+    </div>
+  </section>
+<% end %>
+
+<section class="admin-workflow-runner admin-panel" data-admin-workflow-runner data-admin-workflow-key="<%= @workflow.key %>" data-admin-workflow-run-id="<%= @workflow_run_id %>" data-admin-workflow-progress-url="<%= admin_workflow_progress_path(@workflow.key, run_id: @workflow_run_id) if @workflow_run_id.present? %>">
+  <div class="admin-section-heading">
+    <h2>ステップ実行</h2>
+    <p>個別実行も残しつつ、まとまった処理はバックグラウンドで順番に実行できます。</p>
+  </div>
+
+  <% if @workflow_run_id.present? %>
+    <p class="admin-workflow-current" data-admin-workflow-current-step>
+      現在: <%= current_step&.dig(:label) || "完了" %>
+    </p>
+  <% end %>
+
+  <% if @workflow.key == "full" %>
+    <p class="admin-workflow-parallel-note">全体更新では、JOYSOUND(うたスキ)完了後にJOYSOUNDとDAMを並列実行します。</p>
+  <% end %>
+
+  <ol class="admin-workflow-step-list" data-admin-workflow-step-list>
+    <% @workflow.stages.each do |stage| %>
+      <% stage.branches.each do |branch| %>
+        <% step_number = 0 %>
+        <% branch.steps.each do |step| %>
+          <% resource = Admin::ResourceRegistry.fetch(step.resource_key) %>
+          <% operation = resource.operations.find { |item| item.key == step.operation_key } %>
+          <% next unless operation %>
+          <% next if operation.selection == :required %>
+          <% step_number += 1 if step.numbered %>
+          <% step_key = "#{stage.key}:#{branch.key}:#{step.key}" %>
+          <% step_payload = workflow_steps_by_key[step_key] %>
+          <% step_status = @workflow_run_id.present? ? step_payload&.dig(:status) : nil %>
+          <li class="admin-workflow-step admin-workflow-step-<%= step.kind %>" data-admin-workflow-step="<%= step_key %>" data-admin-workflow-status="<%= step_status if step_status.present? %>">
+            <span class="admin-workflow-action-number"><%= step.numbered ? step_number : "任意" %></span>
+            <span class="admin-workflow-step-body">
+              <span><%= branch.label %> / <%= resource.label %></span>
+              <strong><%= operation.label %></strong>
+              <small><%= step.note %></small>
+              <span class="admin-workflow-action-tags"><%= step.cadence %> / <%= admin_operation_status_labels(operation).join(" / ") %></span>
+              <span class="admin-workflow-step-progress" data-admin-workflow-step-progress><%= admin_workflow_step_status_label(step_payload, running: @workflow_run_id.present?, numbered: step.numbered) %></span>
+            </span>
+            <%= button_tag type: :button, class: "admin-button btn btn-sm btn-outline", data: { admin_operation_trigger: true, admin_operation_resource: resource.key, admin_operation_key: operation.key, admin_operation_label: operation.label } do %>
+              <%= admin_icon(:action) %>
+              <span>個別実行</span>
+            <% end %>
+          </li>
+        <% end %>
+      <% end %>
+    <% end %>
+  </ol>
+</section>
+
+<% @workflow_groups.each do |group| %>
+  <section class="admin-workflow-group admin-workflow-detail-group">
+    <header>
+      <span class="admin-workflow-group-icon"><%= admin_icon(group[:icon]) %></span>
+      <div>
+        <h2><%= group[:label] %></h2>
+        <p><%= group[:description] %></p>
+      </div>
+    </header>
+
+    <div class="admin-workflow-metrics">
+      <% group[:metrics].each do |metric| %>
+        <%= link_to metric[:path], class: "admin-workflow-metric" do %>
+          <span><%= metric[:label] %></span>
+          <strong><%= number_with_delimiter(metric[:value]) %></strong>
+          <small><%= metric[:unit] %></small>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
+<% @workflow_operation_resources.each do |resource| %>
+  <%= render "admin/resources/operation_modal", resource:, operations: resource.operations %>
+<% end %>

--- a/app/views/admin/workflow/show.html.erb
+++ b/app/views/admin/workflow/show.html.erb
@@ -88,7 +88,9 @@
           <% step_key = "#{stage.key}:#{branch.key}:#{step.key}" %>
           <% step_payload = workflow_steps_by_key[step_key] %>
           <% step_status = @workflow_run_id.present? ? step_payload&.dig(:status) : nil %>
-          <li class="admin-workflow-step admin-workflow-step-<%= step.kind %>" data-admin-workflow-step="<%= step_key %>" data-admin-workflow-status="<%= step_status if step_status.present? %>">
+          <% step_classes = ["admin-workflow-step", "admin-workflow-step-#{step.kind}"] %>
+          <% step_classes << "admin-workflow-step-manual" unless step.numbered %>
+          <li class="<%= step_classes.join(" ") %>" data-admin-workflow-step="<%= step_key %>" data-admin-workflow-status="<%= step_status if step_status.present? %>">
             <span class="admin-workflow-action-number"><%= step.numbered ? step_number : "任意" %></span>
             <span class="admin-workflow-step-body">
               <span><%= branch.label %> / <%= resource.label %></span>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -16,6 +16,13 @@
         <span>東方カラオケ管理</span>
       <% end %>
       <nav class="admin-nav">
+        <section class="admin-nav-group" aria-label="運用">
+          <h2>運用</h2>
+          <%= link_to admin_workflow_path, class: ["admin-nav-link", ("admin-nav-link-active" if controller_path == "admin/workflow")] do %>
+            <span class="admin-nav-icon"><%= admin_icon(:workflow) %></span>
+            <span>運用フロー</span>
+          <% end %>
+        </section>
         <% admin_navigation_groups.each do |group_label, resources| %>
           <section class="admin-nav-group" aria-label="<%= group_label %>">
             <h2><%= group_label %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root to: "dashboard#show"
+    get :workflow, to: "workflow#index"
+    get "workflow/:workflow_key", to: "workflow#show", as: :workflow_steps
+    post "workflow/:workflow_key/run", to: "workflow#run", as: :run_workflow
+    get "workflow/:workflow_key/progress", to: "workflow#progress", as: :workflow_progress
 
     resources :originals
     resources :original_songs

--- a/test/controllers/admin/resources_controller_test.rb
+++ b/test/controllers/admin/resources_controller_test.rb
@@ -805,6 +805,20 @@ module Admin
       assert_equal 120, payload['current']
     end
 
+    test 'operation progress endpoint accepts polling params without unpermitted warnings' do
+      original_behavior = ActionController::Parameters.action_on_unpermitted_parameters
+      ActionController::Parameters.action_on_unpermitted_parameters = :raise
+      progress_id = SecureRandom.uuid
+      OperationProgress.enqueue!(progress_id, label: '確認中')
+
+      get operation_progress_admin_display_artists_path(operation: 'validate_display_artist_urls', operation_progress_id: progress_id)
+
+      assert_response :success
+      assert_equal 'queued', response.parsed_body['state']
+    ensure
+      ActionController::Parameters.action_on_unpermitted_parameters = original_behavior
+    end
+
     test 'method operation receives progress callback and completes progress' do
       progress_id = SecureRandom.uuid
       fetch = lambda do |progress: nil|

--- a/test/controllers/admin/resources_controller_test.rb
+++ b/test/controllers/admin/resources_controller_test.rb
@@ -44,7 +44,9 @@ module Admin
       assert_select '.admin-dashboard-bar-row', text: /YouTube Music/
       assert_select '.admin-dashboard-bar-row', text: /Spotify/
       assert_select '.admin-dashboard-bar-row', text: /LINE MUSIC/
-      assert_select '.admin-dashboard-action-link', text: 'DAM楽曲を取得'
+      assert_select '.admin-dashboard-workflow', false
+      assert_select 'a.admin-nav-link', text: /運用フロー/
+      assert_select '.admin-dashboard-action-link', text: 'DAM候補をカラオケ楽曲へ登録'
       assert_select '.admin-dashboard-insight-group h3', text: 'データ状態'
       assert_select '.admin-dashboard-insight-group h3', text: 'マスタデータ'
       assert_select '.admin-dashboard-insight-group h3', text: 'ミュージックポスト'
@@ -54,6 +56,124 @@ module Admin
       assert_select '.admin-dashboard-management-primary', text: /まず見る/
       assert_select '.admin-dashboard-management-primary', text: /カラオケ配信曲/
       assert_select 'a.admin-dashboard-management-link', text: /原曲/
+    end
+
+    test 'workflow page groups actions by delivery type' do
+      get admin_workflow_path
+
+      assert_response :success
+      assert_select 'h1', text: '運用フロー'
+      assert_select '.admin-nav-link-active', text: /運用フロー/
+      assert_select '.admin-workflow-group h2', text: 'DAM'
+      assert_select '.admin-workflow-group h2', text: 'JOYSOUND'
+      assert_select '.admin-workflow-group h2', text: 'JOYSOUND(うたスキ)'
+      assert_select '.admin-workflow-group h2', text: '共通作業'
+      assert_select '.admin-workflow-action', text: /DAM候補一覧を取得/
+      assert_select '.admin-workflow-action', text: /DAM候補一覧とDAMアーティストURLを作る/
+      assert_select '.admin-workflow-action', text: /JOYSOUND候補をカラオケ楽曲へ登録/
+      assert_select '.admin-workflow-action', text: /ミュージックポスト一覧を取得/
+      assert_select '.admin-workflow-action', text: /原曲未設定TSVをエクスポート/
+      assert_select '.admin-workflow-action', { text: /楽曲TSVをエクスポート/, count: 0 }
+      assert_select 'a.admin-workflow-run-link', text: /ステップ実行/
+      assert_select 'a.admin-workflow-action', false
+      assert_select 'button.admin-workflow-action[data-admin-operation-trigger][data-admin-operation-resource="dam_song"][data-admin-operation-key="fetch_dam_touhou_songs"]'
+      assert_select '.admin-workflow-action-number', text: '1'
+      assert_select '.admin-workflow-metric', text: /期限切れ/
+      assert_select '.admin-workflow-question-list li', text: /JOYSOUND\(うたスキ\) → JOYSOUND → DAM/
+    end
+
+    test 'workflow step page renders auto run and individual actions' do
+      get admin_workflow_steps_path('full')
+
+      assert_response :success
+      assert_select 'h1', text: '全体更新'
+      assert_select 'form[action=?]', admin_run_workflow_path('full')
+      assert_select '.admin-workflow-parallel-note', text: /JOYSOUNDとDAMを並列実行/
+      assert_select '.admin-workflow-step', text: /ミュージックポスト一覧を取得/
+      assert_select '.admin-workflow-step', text: /JOYSOUND候補一覧を取得/
+      assert_select '.admin-workflow-step', text: /DAM候補一覧を取得/
+      assert_select '.admin-workflow-step-progress', text: '未実行'
+      assert_select 'button[data-admin-operation-trigger][data-admin-operation-key="fetch_dam_touhou_songs"]', text: /個別実行/
+    end
+
+    test 'workflow common page excludes selection required actions' do
+      get admin_workflow_steps_path('common')
+
+      assert_response :success
+      assert_select '.admin-workflow-step', text: /原曲未設定TSVをエクスポート/
+      assert_select '.admin-workflow-step', { text: /楽曲TSVをエクスポート/, count: 0 }
+      assert_select 'button[data-admin-operation-key="export_songs"]', 0
+    end
+
+    test 'workflow step page shows active run status' do
+      run_id = SecureRandom.uuid
+      WorkflowRunProgress.create!(run_id, workflow: WorkflowDefinition.fetch('dam'))
+
+      get admin_workflow_steps_path('dam')
+
+      assert_response :success
+      assert_select '.admin-workflow-status', text: /実行状況/
+      assert_select '[data-admin-workflow-status-label]', text: 'DAMを開始待ちです'
+      assert_select '[data-admin-workflow-status-state]', text: 'ジョブ待機中'
+      assert_select '[data-admin-workflow-status-current]', text: 'DAM候補一覧を取得'
+      assert_select '[data-admin-workflow-status-count]', text: '0 / 3'
+      assert_select '[data-admin-workflow-current-step]', text: '現在: DAM候補一覧を取得'
+      assert_select '.admin-workflow-step-progress', text: '順番待ち'
+      assert_select 'button[disabled]', text: /自動実行中/
+      assert_select '[data-admin-workflow-runner][data-admin-workflow-run-id=?]', run_id
+    end
+
+    test 'workflow run enqueues background job' do
+      assert_enqueued_with(job: WorkflowRunJob, queue: 'admin_operations') do
+        post admin_run_workflow_path('dam')
+      end
+
+      assert_redirected_to %r{/admin/workflow/dam\?run_id=}
+      run_id = response.redirect_url[/run_id=([0-9a-f-]{36})/, 1]
+      payload = WorkflowRunProgress.read(run_id)
+      assert_equal 'queued', payload[:state]
+      assert_equal 'DAM', payload.dig(:workflow, :workflow_label)
+      assert_equal 3, payload.dig(:workflow, :total_steps)
+    end
+
+    test 'workflow run redirects to active overlapping run instead of starting duplicate' do
+      run_id = SecureRandom.uuid
+      WorkflowRunProgress.create!(run_id, workflow: WorkflowDefinition.fetch('full'))
+      job_count = enqueued_jobs.size
+
+      post admin_run_workflow_path('dam')
+
+      assert_equal job_count, enqueued_jobs.size
+      assert_redirected_to admin_workflow_steps_path('full', run_id:)
+      assert_equal '全体更新を実行中のため、新しい自動実行は開始しませんでした。', flash[:alert]
+    end
+
+    test 'workflow progress keeps step detail after lifecycle updates' do
+      run_id = SecureRandom.uuid
+      workflow = WorkflowDefinition.fetch('music_post')
+      WorkflowRunProgress.create!(run_id, workflow:)
+      WorkflowRunProgress.start!(run_id, workflow:)
+      child_progress_id = SecureRandom.uuid
+      WorkflowRunProgress.mark_step!(
+        run_id,
+        'music_post:music_post:joysound_music_post:fetch_music_post',
+        status: 'running',
+        progress_id: child_progress_id
+      )
+      OperationProgress.update!(
+        child_progress_id,
+        state: 'running',
+        percentage: 42,
+        status: '取得中',
+        label: 'ミュージックポスト一覧を取得しています'
+      )
+
+      payload = WorkflowRunProgress.read(run_id)
+
+      assert_equal 'running', payload[:state]
+      assert_equal 7, payload.dig(:workflow, :steps).size
+      assert_equal 'ミュージックポスト一覧を取得', payload.dig(:workflow, :current_step, :label)
+      assert_equal 6, payload[:percentage]
     end
 
     test 'all resources render index and show pages' do
@@ -471,7 +591,15 @@ module Admin
 
       assert_response :success
       assert_select 'form.admin-inline-operation', false
-      assert_select '.admin-operation-dropdown-wrap'
+      assert_select '.admin-operation-guide'
+      assert_select '.admin-operation-guide-kicker', text: 'カラオケ配信曲'
+      assert_select '.admin-operation-guide h2', text: '運用アクション'
+      assert_select '.admin-operation-guide-group h3', text: 'TSV入出力'
+      assert_select '.admin-operation-guide-group h3', text: '外部取得'
+      assert_select '.admin-operation-guide-item[data-admin-operation-trigger][data-admin-operation-resource="song"][data-admin-operation-key="export_songs"][data-admin-operation-label="楽曲TSVをエクスポート"] strong', text: '楽曲TSVをエクスポート'
+      assert_select '.admin-operation-guide-cta', text: /対象を選択して実行/
+      assert_select '.admin-operation-guide-meta small', text: '選択必須'
+      assert_select '.admin-operation-guide-meta small', text: 'バックグラウンド'
       assert_select 'th.admin-select-column'
       assert_select 'input[data-admin-resource-select]', 1
       assert_select 'dialog[data-admin-operation-modal]'
@@ -480,11 +608,9 @@ module Admin
       assert_select '[data-admin-operation-panel="export_songs"] [data-admin-operation-selected-ids]'
       assert_select '[data-admin-operation-panel="export_songs"] [data-admin-operation-selection-note]', text: '対象を選択してください。'
       assert_select '[data-admin-operation-panel="export_songs"] button[data-admin-operation-submit][disabled]'
-      assert_select '.admin-operation-dropdown-group h3', text: 'TSV入出力'
-      assert_select '.admin-operation-dropdown-group h3', text: '外部取得'
       assert_select '.admin-display-settings .admin-operation-dropdown-wrap', false
       assert_select '.admin-table-controls .admin-table-display-settings'
-      assert_select 'a.admin-operation-dropdown-item[href=?][data-admin-operation-trigger][data-admin-operation-key="export_songs"]', operation_admin_songs_path(operation: 'export_songs'), text: '楽曲TSVをエクスポート'
+      assert_select 'a.admin-operation-guide-item[href=?][data-admin-operation-trigger][data-admin-operation-resource="song"][data-admin-operation-key="export_songs"][data-admin-operation-label="楽曲TSVをエクスポート"] strong', operation_admin_songs_path(operation: 'export_songs'), text: '楽曲TSVをエクスポート'
     end
 
     test 'all operations have explicit descriptions' do
@@ -637,7 +763,7 @@ module Admin
       get operation_admin_dam_songs_path(operation: 'fetch_dam_touhou_songs')
 
       assert_response :success
-      assert_select 'h1', text: '東方DAM楽曲を取得'
+      assert_select 'h1', text: 'DAM候補一覧を取得'
       assert_select 'form[data-admin-operation-form][data-admin-operation-estimated-seconds="40"]'
       assert_select 'form[data-admin-operation-form][data-admin-operation-async="true"]'
     end
@@ -713,7 +839,7 @@ module Admin
 
       assert_response :accepted
       payload = response.parsed_body
-      assert_equal '東方DAM楽曲を取得のバックグラウンド処理を開始しました。', payload['message']
+      assert_equal 'DAM候補一覧を取得のバックグラウンド処理を開始しました。', payload['message']
       assert_equal 'queued', payload.dig('progress', 'state')
       assert_equal '待機中', payload.dig('progress', 'status')
     end

--- a/test/controllers/admin/resources_controller_test.rb
+++ b/test/controllers/admin/resources_controller_test.rb
@@ -70,6 +70,8 @@ module Admin
       assert_select '.admin-workflow-group h2', text: '共通作業'
       assert_select '.admin-workflow-action', text: /DAM候補一覧を取得/
       assert_select '.admin-workflow-action', text: /DAM候補一覧とDAMアーティストURLを作る/
+      assert_select '.admin-workflow-action', text: /DAM楽曲URLから候補を追加/
+      assert_select '.admin-workflow-action', text: /JOYSOUND楽曲URLから候補を追加/
       assert_select '.admin-workflow-action', text: /JOYSOUND候補をカラオケ楽曲へ登録/
       assert_select '.admin-workflow-action', text: /ミュージックポスト一覧を取得/
       assert_select '.admin-workflow-action', text: /原曲未設定TSVをエクスポート/
@@ -91,7 +93,9 @@ module Admin
       assert_select '.admin-workflow-parallel-note', text: /JOYSOUNDとDAMを並列実行/
       assert_select '.admin-workflow-step', text: /ミュージックポスト一覧を取得/
       assert_select '.admin-workflow-step', text: /JOYSOUND候補一覧を取得/
+      assert_select '.admin-workflow-step', text: /JOYSOUND楽曲URLから候補を追加/
       assert_select '.admin-workflow-step', text: /DAM候補一覧を取得/
+      assert_select '.admin-workflow-step', text: /DAM楽曲URLから候補を追加/
       assert_select '.admin-workflow-step-progress', text: '未実行'
       assert_select 'button[data-admin-operation-trigger][data-admin-operation-key="fetch_dam_touhou_songs"]', text: /個別実行/
     end
@@ -101,8 +105,33 @@ module Admin
 
       assert_response :success
       assert_select '.admin-workflow-step', text: /原曲未設定TSVをエクスポート/
+      assert_select '.admin-workflow-action-number', { text: '任意', minimum: 1 }
+      assert_select '.admin-workflow-action-number', { text: /\A\d+\z/, count: 0 }
       assert_select '.admin-workflow-step', { text: /楽曲TSVをエクスポート/, count: 0 }
       assert_select 'button[data-admin-operation-key="export_songs"]', 0
+    end
+
+    test 'resource action guide hides actions that are available in workflow' do
+      get admin_dam_songs_path
+
+      assert_response :success
+      assert_select '.admin-operation-guide', 0
+
+      get admin_songs_path
+
+      assert_response :success
+      assert_select '.admin-operation-guide-item', text: /楽曲TSVをエクスポート/
+      assert_select '.admin-operation-guide-item', { text: /原曲未設定TSVをエクスポート/, count: 0 }
+      assert_select '.admin-operation-guide-item', { text: /DAM候補をカラオケ楽曲へ登録/, count: 0 }
+    end
+
+    test 'cleanup orphan display artists operation renders tsv output checkbox' do
+      get operation_admin_display_artists_path(operation: 'cleanup_orphan_display_artists')
+
+      assert_response :success
+      assert_select 'h1', text: '孤立アーティストを削除'
+      assert_select 'input[type="checkbox"][name="operation_fields[export_tsv]"][checked="checked"]'
+      assert_select '.admin-checkbox-field', text: /削除したアーティストをTSVで出力する/
     end
 
     test 'workflow step page shows active run status' do
@@ -595,11 +624,11 @@ module Admin
       assert_select '.admin-operation-guide-kicker', text: 'カラオケ配信曲'
       assert_select '.admin-operation-guide h2', text: '運用アクション'
       assert_select '.admin-operation-guide-group h3', text: 'TSV入出力'
-      assert_select '.admin-operation-guide-group h3', text: '外部取得'
+      assert_select '.admin-operation-guide-group h3', { text: '外部取得', count: 0 }
       assert_select '.admin-operation-guide-item[data-admin-operation-trigger][data-admin-operation-resource="song"][data-admin-operation-key="export_songs"][data-admin-operation-label="楽曲TSVをエクスポート"] strong', text: '楽曲TSVをエクスポート'
       assert_select '.admin-operation-guide-cta', text: /対象を選択して実行/
       assert_select '.admin-operation-guide-meta small', text: '選択必須'
-      assert_select '.admin-operation-guide-meta small', text: 'バックグラウンド'
+      assert_select '.admin-operation-guide-meta small', { text: 'バックグラウンド', count: 0 }
       assert_select 'th.admin-select-column'
       assert_select 'input[data-admin-resource-select]', 1
       assert_select 'dialog[data-admin-operation-modal]'
@@ -740,7 +769,7 @@ module Admin
       get operation_admin_dam_songs_path(operation: 'fetch_dam_song')
 
       assert_response :success
-      assert_select 'h1', text: 'DAM楽曲を取得'
+      assert_select 'h1', text: 'DAM楽曲URLから候補を追加'
       assert_select '.admin-operation-description', text: /入力されたDAM楽曲URLから/
       assert_select '.admin-operation-description a[href=?]', Constants::Karaoke::Dam::SONG_URL, text: Constants::Karaoke::Dam::SONG_URL
       assert_select 'form[data-admin-operation-form][data-admin-operation-action="FetchDamSong"]'
@@ -836,6 +865,31 @@ module Admin
       end
 
       assert_redirected_to admin_dam_songs_path
+      progress = OperationProgress.read(progress_id)
+      assert_equal 'completed', progress[:state]
+      assert_equal 100, progress[:percentage]
+    end
+
+    test 'dam artist reading operation delegates to dam artist url fetcher' do
+      progress_id = SecureRandom.uuid
+      called = false
+      fetch = lambda do |progress: nil|
+        called = true
+        progress.call(percentage: 55, status: '外部サイト取得中', label: 'DAMアーティスト読みを取得しています')
+      end
+
+      original_fetch = DamArtistUrl.method(:fill_dam_artist_readings)
+      DamArtistUrl.define_singleton_method(:fill_dam_artist_readings, &fetch)
+      begin
+        perform_enqueued_jobs do
+          post operation_admin_display_artists_path, params: { operation: 'fetch_dam_artist', operation_progress_id: progress_id }
+        end
+      ensure
+        DamArtistUrl.define_singleton_method(:fill_dam_artist_readings, &original_fetch)
+      end
+
+      assert called
+      assert_redirected_to admin_display_artists_path
       progress = OperationProgress.read(progress_id)
       assert_equal 'completed', progress[:state]
       assert_equal 100, progress[:percentage]
@@ -1008,12 +1062,30 @@ module Admin
       orphan = DisplayArtist.create!(karaoke_type: 'DAM', name: 'Orphan', url: 'https://example.com/orphan')
 
       assert_difference -> { DisplayArtist.count }, -1 do
-        post operation_admin_display_artists_path, params: { operation: operation_index(:display_artist, :cleanup_orphan_display_artists) }
+        post operation_admin_display_artists_path, params: {
+          operation: operation_index(:display_artist, :cleanup_orphan_display_artists),
+          operation_fields: { export_tsv: '1' }
+        }
       end
 
       assert_response :success
       assert_includes response.headers['Content-Disposition'], 'deleted_orphan_display_artists.tsv'
       assert_includes response.body, orphan.id
+    end
+
+    test 'cleanup orphan display artists can skip tsv output' do
+      DisplayArtist.create!(karaoke_type: 'DAM', name: 'Orphan Without TSV', url: 'https://example.com/orphan-without-tsv')
+
+      assert_difference -> { DisplayArtist.count }, -1 do
+        post operation_admin_display_artists_path, params: {
+          operation: operation_index(:display_artist, :cleanup_orphan_display_artists),
+          operation_fields: { export_tsv: '0' }
+        }
+      end
+
+      assert_redirected_to admin_display_artists_path
+      follow_redirect!
+      assert_select '.admin-flash-notice', text: /TSVは出力していません/
     end
 
     test 'runs joysound music post maintenance operation through service' do

--- a/test/models/admin/operation_progress_test.rb
+++ b/test/models/admin/operation_progress_test.rb
@@ -33,8 +33,10 @@ module Admin
       assert_equal 4, updated[:total]
       assert_equal '進行中', updated[:detail]
 
-      OperationProgress.complete!(id, label: '完了しました')
-      assert_equal 'completed', OperationProgress.read(id)[:state]
+      OperationProgress.complete!(id, label: '完了しました', detail: '変更なし')
+      completed = OperationProgress.read(id)
+      assert_equal 'completed', completed[:state]
+      assert_equal '変更なし', completed[:detail]
 
       OperationProgress.fail!(id, message: '失敗しました')
       failed = OperationProgress.read(id)

--- a/test/models/admin/operation_runner_test.rb
+++ b/test/models/admin/operation_runner_test.rb
@@ -10,16 +10,18 @@ module Admin
       selected.original_songs << original_song
       resource = ResourceRegistry.fetch(:song)
       operation = resource.operations.find { |item| item.key == 'export_songs' }
+      progress_id = SecureRandom.uuid
 
       result = OperationRunner.new(
         resource:,
         operation:,
         record: nil,
-        params: { selected_ids: [selected.id], operation_progress_id: SecureRandom.uuid },
+        params: { selected_ids: [selected.id], operation_progress_id: progress_id },
         scope: Song.where(id: [selected.id, excluded.id])
       ).run
 
       assert_equal 'songs.tsvを生成しました。', result.message
+      assert_equal '変更なし（追加・更新・削除はありません）', OperationProgress.read(progress_id)[:detail]
       assert_equal 'songs.tsv', result.download_filename
       assert_includes result.download_data, selected.title
       assert_includes result.download_data, original_song.title
@@ -69,16 +71,18 @@ module Admin
       upload = Rack::Test::UploadedFile.new(path, 'text/tab-separated-values')
       resource = ResourceRegistry.fetch(:song)
       operation = resource.operations.find { |item| item.key == 'import_songs_with_original_songs' }
+      progress_id = SecureRandom.uuid
 
       result = OperationRunner.new(
         resource:,
         operation:,
         record: nil,
-        params: { operation_fields: { tsv_file: upload }, operation_progress_id: SecureRandom.uuid },
+        params: { operation_fields: { tsv_file: upload }, operation_progress_id: progress_id },
         scope: Song.all
       ).run
 
       assert_equal 'インポートが完了しました。更新件数: 1件、スキップ件数: 2件', result.message
+      assert_includes OperationProgress.read(progress_id)[:detail], 'カラオケ配信曲 更新1件'
       assert_equal [original_song], song.reload.original_songs.to_a
       assert_equal 'https://youtube.example/import', song.youtube_url
     ensure


### PR DESCRIPTION
## 概要
- 運用フロー画面を追加し、JOYSOUND(うたスキ) → JOYSOUND → DAM の流れでステップ実行できるようにしました。
- URL指定取得を運用フローの任意アクションに追加し、各リソース一覧からは運用フロー掲載済みアクションを非表示にしました。
- 自動実行中の進捗、現在ステップ、DB変更サマリー、重複実行防止を追加しました。
- 孤立アーティスト削除で、削除結果TSVを出力するかチェックボックスで選べるようにしました。
- DAMアーティスト読み補完の呼び出し先不整合と、進捗確認時の unpermitted parameter 警告を修正しました。

## 確認
- `make minitest`
- `make rubocop`
- Playwright: `/admin/workflow`, `/admin/songs`, `/admin/dam_songs`, `/admin/display_artists/operation?operation=cleanup_orphan_display_artists`
- デスクトップ幅 `1440x900`, `1920x1080` で確認。モバイル確認は運用対象外のため省略しています。