### PR TITLE
[codex] 管理画面のリンク遷移を部分描画にする

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -126,7 +126,13 @@
   min-width: 0;
   overflow-y: auto;
   padding: 32px 36px 44px;
+  transition: opacity 120ms ease;
   width: calc(100vw - 280px);
+}
+
+body[data-admin-navigation="loading"] .admin-main {
+  cursor: progress;
+  opacity: 0.68;
 }
 
 .admin-index-content {
@@ -2546,6 +2552,9 @@ th.admin-actions-column {
 @media (max-width: 860px) {
   .admin-shell {
     display: block;
+    height: auto;
+    min-height: 100vh;
+    overflow: auto;
   }
 
   .admin-sidebar {
@@ -2555,8 +2564,15 @@ th.admin-actions-column {
   }
 
   .admin-main {
+    height: auto;
+    min-height: 100vh;
     padding: 22px 16px 32px;
     width: 100%;
+  }
+
+  .admin-index-content {
+    height: auto;
+    min-height: calc(100vh - 54px);
   }
 
   .admin-dashboard-hero-main {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -68,6 +68,15 @@ const browserUrl = (url) => {
   return nextUrl
 }
 
+const setupAdminPageBehaviors = () => {
+  setupAdminFilterForms()
+  setupAdminInfiniteScroll()
+  setupAdminResourceSelection()
+  setupAdminOperationModal()
+  setupAdminOperationForms()
+  setupAdminWorkflowRunner()
+}
+
 const replaceAdminResourceContent = async (url, { pushState = true } = {}) => {
   const response = await fetch(adminContentUrl(url), {
     headers: {
@@ -84,11 +93,7 @@ const replaceAdminResourceContent = async (url, { pushState = true } = {}) => {
 
   currentContent.outerHTML = payload.html
   if (pushState) window.history.pushState({}, "", browserUrl(url))
-  setupAdminFilterForms()
-  setupAdminInfiniteScroll()
-  setupAdminResourceSelection()
-  setupAdminOperationModal()
-  setupAdminOperationForms()
+  setupAdminPageBehaviors()
 }
 
 const isAsyncAdminLink = (link) => {
@@ -127,15 +132,112 @@ const setupAdminAsyncIndex = () => {
     })
   })
 
+}
+
+document.addEventListener("DOMContentLoaded", setupAdminAsyncIndex)
+
+let adminPageNavigationController
+
+const adminPageUrl = (url) => {
+  const nextUrl = new URL(url, window.location.origin)
+  nextUrl.searchParams.delete("partial")
+  return nextUrl
+}
+
+const isPrimaryNavigationClick = (event) =>
+  event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
+
+const isAsyncAdminPageLink = (link, event) => {
+  if (!link || !isPrimaryNavigationClick(event)) return false
+  if (event.defaultPrevented) return false
+  if (link.matches("[data-admin-operation-trigger]")) return false
+  if (link.target || link.hasAttribute("download")) return false
+  if (link.dataset.turbo === "false" || link.dataset.adminFullPage === "true") return false
+  if (link.dataset.method && link.dataset.method.toLowerCase() !== "get") return false
+  if (isAsyncAdminLink(link)) return false
+
+  const url = adminPageUrl(link.href)
+  return url.origin === window.location.origin && url.pathname.startsWith("/admin/")
+}
+
+const replaceAdminPage = (html, url, { pushState = true } = {}) => {
+  const nextDocument = new DOMParser().parseFromString(html, "text/html")
+  const nextContent = nextDocument.querySelector("[data-admin-page-content]")
+  const currentContent = document.querySelector("[data-admin-page-content]")
+
+  if (!nextContent || !currentContent) throw new Error("Admin page content was not found.")
+
+  const nextSidebar = nextDocument.querySelector(".admin-sidebar")
+  const currentSidebar = document.querySelector(".admin-sidebar")
+  if (nextSidebar && currentSidebar) currentSidebar.outerHTML = nextSidebar.outerHTML
+
+  currentContent.replaceWith(nextContent)
+  document.title = nextDocument.title || document.title
+  if (pushState) window.history.pushState({}, "", adminPageUrl(url))
+
+  const pageContent = document.querySelector("[data-admin-page-content]")
+  pageContent?.scrollTo({ top: 0, left: 0 })
+  setupAdminPageBehaviors()
+}
+
+const fetchAndReplaceAdminPage = async (url, { pushState = true } = {}) => {
+  if (adminPageNavigationController) adminPageNavigationController.abort()
+
+  const controller = new AbortController()
+  adminPageNavigationController = controller
+  document.body.dataset.adminNavigation = "loading"
+  document.querySelector("[data-admin-page-content]")?.setAttribute("aria-busy", "true")
+
+  try {
+    const response = await fetch(adminPageUrl(url), {
+      credentials: "same-origin",
+      headers: {
+        Accept: "text/html",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      signal: controller.signal,
+    })
+
+    if (!response.ok) throw new Error(`Request failed: ${response.status}`)
+
+    replaceAdminPage(await response.text(), response.url, { pushState })
+  } finally {
+    if (adminPageNavigationController === controller) {
+      delete document.body.dataset.adminNavigation
+      document.querySelector("[data-admin-page-content]")?.removeAttribute("aria-busy")
+      adminPageNavigationController = undefined
+    }
+  }
+}
+
+const setupAdminPageNavigation = () => {
+  if (document.documentElement.dataset.adminPageNavigationInitialized === "true") return
+
+  document.documentElement.dataset.adminPageNavigationInitialized = "true"
+  document.addEventListener("click", (event) => {
+    const link = event.target.closest("a")
+    if (!isAsyncAdminPageLink(link, event)) return
+
+    event.preventDefault()
+    fetchAndReplaceAdminPage(link.href).catch((error) => {
+      if (error.name === "AbortError") return
+
+      console.error(error)
+      window.location.href = link.href
+    })
+  })
+
   window.addEventListener("popstate", () => {
-    replaceAdminResourceContent(window.location.href, { pushState: false }).catch((error) => {
+    fetchAndReplaceAdminPage(window.location.href, { pushState: false }).catch((error) => {
+      if (error.name === "AbortError") return
+
       console.error(error)
       window.location.reload()
     })
   })
 }
 
-document.addEventListener("DOMContentLoaded", setupAdminAsyncIndex)
+document.addEventListener("DOMContentLoaded", setupAdminPageNavigation)
 
 const setupAdminFilterForms = () => {
   document.querySelectorAll("[data-admin-filter-form]").forEach((form) => {

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -37,7 +37,7 @@
       </nav>
     </aside>
 
-    <main class="admin-main">
+    <main class="admin-main" data-admin-page-content>
       <% if notice.present? %>
         <div class="admin-flash admin-flash-notice alert alert-success"><%= notice %></div>
       <% end %>


### PR DESCRIPTION
## 概要

管理画面内の通常 GET リンクを、ページ全体の再描画ではなく本文領域の差し替えで遷移するようにしました。

## 変更内容

- 管理画面レイアウトの `<main>` に差し替え対象を示す `data-admin-page-content` を追加
- 管理画面内リンククリック時に HTML を fetch し、本文領域とサイドバーの active 状態だけを置換
- 既存の一覧ソート・検索・ページングの JSON 部分更新は維持
- 連続クリック時の abort、戻る/進む、遷移中の軽い busy 表現を追加
- モバイル幅で本文へスクロールできるよう既存レイアウトを補正

## 期待される効果

リンククリックごとの全画面再描画を減らし、管理画面内の移動を軽くします。JS/CSS の再読み込みやサイドバーの再構築を避けるため、一覧・詳細・運用フロー間の体感速度と操作継続性が改善します。

## 検証

- `devbox run yarn build`
- `devbox run yarn build:css`
- `make minitest`
- `make rubocop`
- Playwright CLI による UI 確認
  - `http://localhost:3000/admin`
  - ダッシュボード → カラオケ配信曲
  - 一覧 → 詳細 → 一覧
  - サイドバー → 運用フロー → 全体更新
  - 一覧ソート
  - viewport: `375x812`, `1440x900`, `1920x1080`
  - console errors/warnings: 0

## 補足

POST/DELETE などデータ変更を伴う操作は従来どおり Rails の通常遷移を残しています。