### PR TITLE
perf: パフォーマンス改善（ダッシュボード集計・クエリ最適化・インフラ設定）

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,3 +50,8 @@ Rails/SkipsModelValidations:
 Style/SignalException:
   Exclude:
     - app/avo/actions/*
+
+# 逐次/並列(SCRAPING_THREAD_COUNT)両対応にした分だけ行数が増えたため許容
+Metrics/ModuleLength:
+  Exclude:
+    - app/models/concerns/parallel_processor.rb

--- a/Gemfile
+++ b/Gemfile
@@ -43,4 +43,5 @@ gem 'parallel', '~> 2.1'
 gem 'pundit'
 gem 'ransack'
 
+gem "solid_cache"
 gem "solid_queue", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_queue (1.4.0)
       activejob (>= 7.1)
       activerecord (>= 7.1)
@@ -406,6 +410,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   selenium-webdriver
+  solid_cache
   solid_queue (~> 1.4)
   sprockets-rails
   web-console (>= 3.3.0)

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -11,19 +11,85 @@ module Admin
 
     private
 
+    # 全スカラー集計を per-request メモ化 + cross-request 低レベルキャッシュの
+    # 二重構造で取得する。@dashboard_counts のメモ化により、1リクエスト内では
+    # cache.fetch は1回だけ呼ばれる (test 環境の :null_store でも計算は1回で済む)。
+    def dashboard_counts
+      @dashboard_counts ||= Rails.cache.fetch('admin:dashboard:v1', expires_in: 5.minutes) { compute_dashboard_counts }
+    end
+
+    # キャッシュに格納するのはプリミティブ値 (整数・文字列) と、それらの Hash/配列のみ。
+    # ResourceRegistry::Resource のような Data オブジェクトは Marshal 化できないため含めない。
+    def compute_dashboard_counts
+      service_counts = distribution_service_counts
+
+      {
+        karaoke_type_counts: Song.group(:karaoke_type).count,
+        distribution_service_counts: service_counts,
+        total_songs: service_counts[:total],
+        linked_songs: Song.touhou_arrange.count,
+        missing_original_songs: Song.missing_original_songs.count,
+        with_original_songs: Song.with_original_songs.count,
+        music_post_with_original_songs: Song.music_post.with_original_songs.count,
+        original_songs: OriginalSong.count,
+        display_artists: DisplayArtist.count,
+        circles: Circle.count,
+        originals: Original.count,
+        karaoke_delivery_models: KaraokeDeliveryModel.count,
+        joysound_music_posts: JoysoundMusicPost.count,
+        music_posts_active: JoysoundMusicPost.where(delivery_deadline_on: Date.current..).count,
+        music_posts_expired: JoysoundMusicPost.where(delivery_deadline_on: ...Date.current).count,
+        management_counts: management_counts
+      }
+    end
+
+    # 総楽曲数と各配信サービスの有無カウントを FILTER 句でまとめて1クエリで取得し、
+    # プリミティブな Hash に変換する。各 FILTER 条件は Song モデルの
+    # youtube/apple_music/youtube_music/spotify/line_music スコープ (where.not(col: ""))
+    # およびニコニコ動画の where.not(nicovideo_url: "") と完全に一致させている。
+    def distribution_service_counts
+      row = Song.select(
+        'COUNT(*) AS total',
+        "COUNT(*) FILTER (WHERE youtube_url <> '') AS youtube_count",
+        "COUNT(*) FILTER (WHERE nicovideo_url <> '') AS nicovideo_count",
+        "COUNT(*) FILTER (WHERE apple_music_url <> '') AS apple_music_count",
+        "COUNT(*) FILTER (WHERE youtube_music_url <> '') AS youtube_music_count",
+        "COUNT(*) FILTER (WHERE spotify_url <> '') AS spotify_count",
+        "COUNT(*) FILTER (WHERE line_music_url <> '') AS line_music_count"
+      ).take
+
+      {
+        total: row.total.to_i,
+        youtube: row.youtube_count.to_i,
+        nicovideo: row.nicovideo_count.to_i,
+        apple_music: row.apple_music_count.to_i,
+        youtube_music: row.youtube_music_count.to_i,
+        spotify: row.spotify_count.to_i,
+        line_music: row.line_music_count.to_i
+      }
+    end
+
+    # navigation_groups の全リソースについて { resource.key => count } を1つの Hash にまとめる。
+    # navigation_groups はキーを index_by してから delete するためリソースキーは全体で一意。
+    def management_counts
+      ResourceRegistry.navigation_groups.each_with_object({}) do |(_label, resources), counts|
+        resources.each { |resource| counts[resource.key] = resource.model.count }
+      end
+    end
+
     def dashboard_summary
-      total = total_songs
-      linked_songs = Song.touhou_arrange.count
-      missing_songs = missing_original_songs_count
+      counts = dashboard_counts
+      total = counts[:total_songs]
+      linked_songs = counts[:linked_songs]
 
       {
         total_songs: total,
         linked_songs:,
-        missing_songs:,
+        missing_songs: counts[:missing_original_songs],
         linked_rate: percentage(linked_songs, total),
-        original_songs: original_songs_count,
-        display_artists: display_artists_count,
-        circles: circles_count
+        original_songs: counts[:original_songs],
+        display_artists: counts[:display_artists],
+        circles: counts[:circles]
       }
     end
 
@@ -37,20 +103,21 @@ module Admin
     end
 
     def distribution_metrics
-      by_type = karaoke_type_counts
-      service_counts = distribution_service_counts
-      total = service_counts.total
+      counts = dashboard_counts
+      by_type = counts[:karaoke_type_counts]
+      service_counts = counts[:distribution_service_counts]
+      total = service_counts[:total]
 
       [
         distribution_metric('DAM', by_type.fetch('DAM', 0), total, 'dam'),
         distribution_metric('JOYSOUND', by_type.fetch('JOYSOUND', 0), total, 'joysound'),
         distribution_metric('ミュージックポスト', by_type.fetch('JOYSOUND(うたスキ)', 0), total, 'music-post'),
-        distribution_metric('YouTube', service_counts.youtube_count, total, 'youtube'),
-        distribution_metric('ニコニコ動画', service_counts.nicovideo_count, total, 'nicovideo'),
-        distribution_metric('Apple Music', service_counts.apple_music_count, total, 'apple'),
-        distribution_metric('YouTube Music', service_counts.youtube_music_count, total, 'youtube-music'),
-        distribution_metric('Spotify', service_counts.spotify_count, total, 'spotify'),
-        distribution_metric('LINE MUSIC', service_counts.line_music_count, total, 'line-music')
+        distribution_metric('YouTube', service_counts[:youtube], total, 'youtube'),
+        distribution_metric('ニコニコ動画', service_counts[:nicovideo], total, 'nicovideo'),
+        distribution_metric('Apple Music', service_counts[:apple_music], total, 'apple'),
+        distribution_metric('YouTube Music', service_counts[:youtube_music], total, 'youtube-music'),
+        distribution_metric('Spotify', service_counts[:spotify], total, 'spotify'),
+        distribution_metric('LINE MUSIC', service_counts[:line_music], total, 'line-music')
       ]
     end
 
@@ -58,51 +125,11 @@ module Admin
       { label:, value:, total:, key:, percentage: percentage(value, total) }
     end
 
-    # 種別分布 (DAM / JOYSOUND / ミュージックポスト) を1クエリで取得する。
-    def karaoke_type_counts
-      @karaoke_type_counts ||= Song.group(:karaoke_type).count
-    end
-
-    # 総楽曲数と各配信サービスの有無カウントを FILTER 句でまとめて1クエリで取得する。
-    # 各 FILTER 条件は Song モデルの youtube/apple_music/youtube_music/spotify/line_music
-    # スコープ (where.not(col: "")) およびニコニコ動画の where.not(nicovideo_url: "") と
-    # 完全に一致させている。
-    def distribution_service_counts
-      @distribution_service_counts ||= Song.select(
-        'COUNT(*) AS total',
-        "COUNT(*) FILTER (WHERE youtube_url <> '') AS youtube_count",
-        "COUNT(*) FILTER (WHERE nicovideo_url <> '') AS nicovideo_count",
-        "COUNT(*) FILTER (WHERE apple_music_url <> '') AS apple_music_count",
-        "COUNT(*) FILTER (WHERE youtube_music_url <> '') AS youtube_music_count",
-        "COUNT(*) FILTER (WHERE spotify_url <> '') AS spotify_count",
-        "COUNT(*) FILTER (WHERE line_music_url <> '') AS line_music_count"
-      ).take
-    end
-
-    # dashboard_summary と insight_groups で共有する母数。同一リクエスト内での重複発行を避ける。
-    def total_songs
-      @total_songs ||= distribution_service_counts.total
-    end
-
-    def missing_original_songs_count
-      @missing_original_songs_count ||= Song.missing_original_songs.count
-    end
-
-    def original_songs_count
-      @original_songs_count ||= OriginalSong.count
-    end
-
-    def display_artists_count
-      @display_artists_count ||= DisplayArtist.count
-    end
-
-    def circles_count
-      @circles_count ||= Circle.count
-    end
-
     def management_groups
+      counts = dashboard_counts[:management_counts]
+
       ResourceRegistry.navigation_groups.map do |label, resources|
-        items = resources.map { |resource| { resource:, count: resource.model.count } }
+        items = resources.map { |resource| { resource:, count: counts.fetch(resource.key) } }
         primary = resources.find { |resource| resource.key == primary_management_resource_key(label) } || resources.first
 
         {
@@ -174,36 +201,38 @@ module Admin
     end
 
     def insight_groups
+      counts = dashboard_counts
+
       [
         {
           label: 'データ状態',
           description: '楽曲と原曲の紐付け状況',
           metrics: [
-            metric('総楽曲数', total_songs, '曲', admin_songs_path),
-            metric('原曲紐付け済み', Song.with_original_songs.count, '曲', admin_songs_path(filters: { original_link: 'linked' })),
-            metric('原曲未紐付け', missing_original_songs_count, '曲', admin_songs_path(filters: { original_link: 'missing' }))
+            metric('総楽曲数', counts[:total_songs], '曲', admin_songs_path),
+            metric('原曲紐付け済み', counts[:with_original_songs], '曲', admin_songs_path(filters: { original_link: 'linked' })),
+            metric('原曲未紐付け', counts[:missing_original_songs], '曲', admin_songs_path(filters: { original_link: 'missing' }))
           ]
         },
         {
           label: 'マスタデータ',
           description: '検索・紐付けに使う基礎データ',
           metrics: [
-            metric('原作', Original.count, '件', admin_originals_path),
-            metric('原曲', original_songs_count, '曲', admin_original_songs_path),
-            metric('サークル', circles_count, '件', admin_circles_path),
-            metric('アーティスト', display_artists_count, '件', admin_display_artists_path),
-            metric('配信機種', KaraokeDeliveryModel.count, '件', admin_karaoke_delivery_models_path)
+            metric('原作', counts[:originals], '件', admin_originals_path),
+            metric('原曲', counts[:original_songs], '曲', admin_original_songs_path),
+            metric('サークル', counts[:circles], '件', admin_circles_path),
+            metric('アーティスト', counts[:display_artists], '件', admin_display_artists_path),
+            metric('配信機種', counts[:karaoke_delivery_models], '件', admin_karaoke_delivery_models_path)
           ]
         },
         {
           label: 'ミュージックポスト',
           description: '取得済みデータと配信期限',
           metrics: [
-            metric('配信曲', karaoke_type_counts.fetch('JOYSOUND(うたスキ)', 0), '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post' })),
-            metric('原曲紐付け済み', Song.music_post.with_original_songs.count, '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post', original_link: 'linked' })),
-            metric('取得済み', JoysoundMusicPost.count, '件', admin_joysound_music_posts_path),
-            metric('期限内', JoysoundMusicPost.where(delivery_deadline_on: Date.current..).count, '件', admin_joysound_music_posts_path(filters: { delivery_deadline_on: 'active' })),
-            metric('期限切れ', JoysoundMusicPost.where(delivery_deadline_on: ...Date.current).count, '件', admin_joysound_music_posts_path(filters: { delivery_deadline_on: 'expired' }))
+            metric('配信曲', counts[:karaoke_type_counts].fetch('JOYSOUND(うたスキ)', 0), '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post' })),
+            metric('原曲紐付け済み', counts[:music_post_with_original_songs], '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post', original_link: 'linked' })),
+            metric('取得済み', counts[:joysound_music_posts], '件', admin_joysound_music_posts_path),
+            metric('期限内', counts[:music_posts_active], '件', admin_joysound_music_posts_path(filters: { delivery_deadline_on: 'active' })),
+            metric('期限切れ', counts[:music_posts_expired], '件', admin_joysound_music_posts_path(filters: { delivery_deadline_on: 'expired' }))
           ]
         }
       ]

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -12,18 +12,18 @@ module Admin
     private
 
     def dashboard_summary
-      total_songs = Song.count
+      total = total_songs
       linked_songs = Song.touhou_arrange.count
-      missing_songs = Song.missing_original_songs.count
+      missing_songs = missing_original_songs_count
 
       {
-        total_songs:,
+        total_songs: total,
         linked_songs:,
         missing_songs:,
-        linked_rate: percentage(linked_songs, total_songs),
-        original_songs: OriginalSong.count,
-        display_artists: DisplayArtist.count,
-        circles: Circle.count
+        linked_rate: percentage(linked_songs, total),
+        original_songs: original_songs_count,
+        display_artists: display_artists_count,
+        circles: circles_count
       }
     end
 
@@ -37,21 +37,67 @@ module Admin
     end
 
     def distribution_metrics
+      by_type = karaoke_type_counts
+      service_counts = distribution_service_counts
+      total = service_counts.total
+
       [
-        distribution_metric('DAM', Song.dam.count, Song.count, 'dam'),
-        distribution_metric('JOYSOUND', Song.joysound.count, Song.count, 'joysound'),
-        distribution_metric('ミュージックポスト', Song.music_post.count, Song.count, 'music-post'),
-        distribution_metric('YouTube', Song.youtube.count, Song.count, 'youtube'),
-        distribution_metric('ニコニコ動画', Song.where.not(nicovideo_url: '').count, Song.count, 'nicovideo'),
-        distribution_metric('Apple Music', Song.apple_music.count, Song.count, 'apple'),
-        distribution_metric('YouTube Music', Song.youtube_music.count, Song.count, 'youtube-music'),
-        distribution_metric('Spotify', Song.spotify.count, Song.count, 'spotify'),
-        distribution_metric('LINE MUSIC', Song.line_music.count, Song.count, 'line-music')
+        distribution_metric('DAM', by_type.fetch('DAM', 0), total, 'dam'),
+        distribution_metric('JOYSOUND', by_type.fetch('JOYSOUND', 0), total, 'joysound'),
+        distribution_metric('ミュージックポスト', by_type.fetch('JOYSOUND(うたスキ)', 0), total, 'music-post'),
+        distribution_metric('YouTube', service_counts.youtube_count, total, 'youtube'),
+        distribution_metric('ニコニコ動画', service_counts.nicovideo_count, total, 'nicovideo'),
+        distribution_metric('Apple Music', service_counts.apple_music_count, total, 'apple'),
+        distribution_metric('YouTube Music', service_counts.youtube_music_count, total, 'youtube-music'),
+        distribution_metric('Spotify', service_counts.spotify_count, total, 'spotify'),
+        distribution_metric('LINE MUSIC', service_counts.line_music_count, total, 'line-music')
       ]
     end
 
     def distribution_metric(label, value, total, key)
       { label:, value:, total:, key:, percentage: percentage(value, total) }
+    end
+
+    # 種別分布 (DAM / JOYSOUND / ミュージックポスト) を1クエリで取得する。
+    def karaoke_type_counts
+      @karaoke_type_counts ||= Song.group(:karaoke_type).count
+    end
+
+    # 総楽曲数と各配信サービスの有無カウントを FILTER 句でまとめて1クエリで取得する。
+    # 各 FILTER 条件は Song モデルの youtube/apple_music/youtube_music/spotify/line_music
+    # スコープ (where.not(col: "")) およびニコニコ動画の where.not(nicovideo_url: "") と
+    # 完全に一致させている。
+    def distribution_service_counts
+      @distribution_service_counts ||= Song.select(
+        'COUNT(*) AS total',
+        "COUNT(*) FILTER (WHERE youtube_url <> '') AS youtube_count",
+        "COUNT(*) FILTER (WHERE nicovideo_url <> '') AS nicovideo_count",
+        "COUNT(*) FILTER (WHERE apple_music_url <> '') AS apple_music_count",
+        "COUNT(*) FILTER (WHERE youtube_music_url <> '') AS youtube_music_count",
+        "COUNT(*) FILTER (WHERE spotify_url <> '') AS spotify_count",
+        "COUNT(*) FILTER (WHERE line_music_url <> '') AS line_music_count"
+      ).take
+    end
+
+    # dashboard_summary と insight_groups で共有する母数。同一リクエスト内での重複発行を避ける。
+    def total_songs
+      @total_songs ||= distribution_service_counts.total
+    end
+
+    def missing_original_songs_count
+      @missing_original_songs_count ||= Song.missing_original_songs.count
+    end
+
+    def original_songs_count
+      @original_songs_count ||= OriginalSong.count
+    end
+
+    def display_artists_count
+      @display_artists_count ||= DisplayArtist.count
+    end
+
+    def circles_count
+      @circles_count ||= Circle.count
     end
 
     def management_groups
@@ -133,9 +179,9 @@ module Admin
           label: 'データ状態',
           description: '楽曲と原曲の紐付け状況',
           metrics: [
-            metric('総楽曲数', Song.count, '曲', admin_songs_path),
+            metric('総楽曲数', total_songs, '曲', admin_songs_path),
             metric('原曲紐付け済み', Song.with_original_songs.count, '曲', admin_songs_path(filters: { original_link: 'linked' })),
-            metric('原曲未紐付け', Song.missing_original_songs.count, '曲', admin_songs_path(filters: { original_link: 'missing' }))
+            metric('原曲未紐付け', missing_original_songs_count, '曲', admin_songs_path(filters: { original_link: 'missing' }))
           ]
         },
         {
@@ -143,9 +189,9 @@ module Admin
           description: '検索・紐付けに使う基礎データ',
           metrics: [
             metric('原作', Original.count, '件', admin_originals_path),
-            metric('原曲', OriginalSong.count, '曲', admin_original_songs_path),
-            metric('サークル', Circle.count, '件', admin_circles_path),
-            metric('アーティスト', DisplayArtist.count, '件', admin_display_artists_path),
+            metric('原曲', original_songs_count, '曲', admin_original_songs_path),
+            metric('サークル', circles_count, '件', admin_circles_path),
+            metric('アーティスト', display_artists_count, '件', admin_display_artists_path),
             metric('配信機種', KaraokeDeliveryModel.count, '件', admin_karaoke_delivery_models_path)
           ]
         },
@@ -153,7 +199,7 @@ module Admin
           label: 'ミュージックポスト',
           description: '取得済みデータと配信期限',
           metrics: [
-            metric('配信曲', Song.music_post.count, '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post' })),
+            metric('配信曲', karaoke_type_counts.fetch('JOYSOUND(うたスキ)', 0), '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post' })),
             metric('原曲紐付け済み', Song.music_post.with_original_songs.count, '曲', admin_songs_path(filters: { karaoke_type: 'joysound_music_post', original_link: 'linked' })),
             metric('取得済み', JoysoundMusicPost.count, '件', admin_joysound_music_posts_path),
             metric('期限内', JoysoundMusicPost.where(delivery_deadline_on: Date.current..).count, '件', admin_joysound_music_posts_path(filters: { delivery_deadline_on: 'active' })),

--- a/app/models/admin/operations/song_tsv_operation.rb
+++ b/app/models/admin/operations/song_tsv_operation.rb
@@ -44,26 +44,28 @@ module Admin
         songs_by_id = fetch_songs_by_id(table)
         original_songs_by_title = fetch_original_songs_by_title(table)
 
-        table.each do |row|
-          song = songs_by_id[row[:id].to_s]
-          original_song_titles = row[:original_songs].to_s.split('/').compact_blank
+        ActiveRecord::Base.transaction do
+          table.each do |row|
+            song = songs_by_id[row[:id].to_s]
+            original_song_titles = row[:original_songs].to_s.split('/').compact_blank
 
-          if song.blank? || original_song_titles.blank?
-            skipped_count += 1
-            next
+            if song.blank? || original_song_titles.blank?
+              skipped_count += 1
+              next
+            end
+
+            song.original_songs = original_song_titles.flat_map { |title| original_songs_by_title[title] || [] }.uniq
+            song.assign_attributes(
+              youtube_url: row[:youtube_url].to_s,
+              nicovideo_url: row[:nicovideo_url].to_s,
+              apple_music_url: row[:apple_music_url].to_s,
+              youtube_music_url: row[:youtube_music_url].to_s,
+              spotify_url: row[:spotify_url].to_s,
+              line_music_url: row[:line_music_url].to_s
+            )
+            song.save!
+            imported_count += 1
           end
-
-          song.original_songs = original_song_titles.flat_map { |title| original_songs_by_title[title] || [] }.uniq
-          song.assign_attributes(
-            youtube_url: row[:youtube_url].to_s,
-            nicovideo_url: row[:nicovideo_url].to_s,
-            apple_music_url: row[:apple_music_url].to_s,
-            youtube_music_url: row[:youtube_music_url].to_s,
-            spotify_url: row[:spotify_url].to_s,
-            line_music_url: row[:line_music_url].to_s
-          )
-          song.save!
-          imported_count += 1
         end
 
         message("インポートが完了しました。更新件数: #{imported_count}件、スキップ件数: #{skipped_count}件")

--- a/app/models/concerns/parallel_processor.rb
+++ b/app/models/concerns/parallel_processor.rb
@@ -7,6 +7,10 @@ module ParallelProcessor
   # デフォルト設定
   DEFAULT_BATCH_SIZE = 1000
   DEFAULT_PROCESS_COUNT = ENV.fetch('PARALLEL_PROCESS_COUNT', 7).to_i
+  # サーバー進捗表示付き処理（process_with_server_progress）専用のスレッド数。
+  # PARALLEL_PROCESS_COUNT とは独立させ、既定は1（逐次実行）にしている。
+  # スクレイパ/ブラウザがまだスレッド安全でないため、既定で並列化されないようにするため。
+  DEFAULT_PROGRESS_THREAD_COUNT = 1
 
   class_methods do
     # バッチ処理で並列実行を行う
@@ -69,7 +73,6 @@ module ParallelProcessor
 
     def process_with_server_progress(collection, progress:, label:, progress_options:)
       total_count = collection_total_count(collection)
-      processed_count = 0
       reporter = Admin::ProgressReporter.new(
         progress:,
         status: progress_options.fetch(:status, "処理中"),
@@ -78,11 +81,34 @@ module ParallelProcessor
       reporter.start(total: total_count)
       return if total_count.zero?
 
-      each_collection_record(collection) do |record|
-        yield(record)
-        processed_count += 1
-        reporter.advance(current: processed_count, total: total_count)
+      thread_count = progress_thread_count
+      processed_count = 0
+      mutex = Mutex.new
+      advance = lambda do
+        mutex.synchronize do
+          processed_count += 1
+          reporter.advance(current: processed_count, total: total_count)
+        end
       end
+
+      if thread_count > 1
+        # SCRAPING_THREAD_COUNT>1 で並列実行するには、yield されるブロック内の処理（スクレイパ/ブラウザ）が
+        # スレッド安全である必要がある。ブラウザ再利用のスレッド毎割り当てが未実装のため、既定値は1（逐次）。
+        records = collection.respond_to?(:to_a) ? collection.to_a : collection
+        Parallel.each(records, in_threads: thread_count) do |record|
+          yield(record)
+          advance.call
+        end
+      else
+        each_collection_record(collection) do |record|
+          yield(record)
+          advance.call
+        end
+      end
+    end
+
+    def progress_thread_count
+      ENV.fetch('SCRAPING_THREAD_COUNT', DEFAULT_PROGRESS_THREAD_COUNT).to_i
     end
 
     def collection_total_count(collection)

--- a/app/models/dam_artist_url.rb
+++ b/app/models/dam_artist_url.rb
@@ -9,6 +9,7 @@ class DamArtistUrl < ApplicationRecord
   def self.fetch_dam_artist(progress: nil)
     records = DamArtistUrl.all
     total_count = records.count
+    pending_urls = DisplayArtist.where(karaoke_type: "DAM", name_reading: "").pluck(:url).to_set
     records.find_each.with_index(1) do |dau, index|
       progress&.call(
         percentage: progress_percentage(index - 1, total_count),
@@ -18,7 +19,7 @@ class DamArtistUrl < ApplicationRecord
         current: index - 1,
         total: total_count
       )
-      dam_artist_page_parser(dau.url) if DisplayArtist.exists?(karaoke_type: "DAM", url: dau.url, name_reading: "")
+      dam_artist_page_parser(dau.url) if pending_urls.include?(dau.url)
       progress&.call(
         percentage: progress_percentage(index, total_count),
         status: "DAMアーティスト取得中",

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -49,12 +49,6 @@ class Song < ApplicationRecord
     original_songs.all? { |original_song| original_song.title.in?(ORIGINAL_OR_OTHER_TITLES) } ? "オリジナル・その他" : "東方アレンジ"
   end
 
-  def self.not_set_original_song
-    includes(:display_artist, :original_songs).select do |song|
-      song if song.original_songs.blank?
-    end
-  end
-
   def self.fetch_joysound_song(url = nil)
     SongExternalSync.fetch_joysound_song(url)
   end
@@ -79,6 +73,7 @@ class Song < ApplicationRecord
     SongExternalSync.prioritized_joysound_music_posts
   end
 
+  # DEPRECATED: 実運用は JoysoundMusicPostManager 経由。将来削除候補。
   def self.refresh_joysound_music_post_song
     SongExternalSync.refresh_joysound_music_post_song
   end
@@ -103,6 +98,7 @@ class Song < ApplicationRecord
     update_dam_delivery_models(progress:)
   end
 
+  # DEPRECATED: 実運用は JoysoundMusicPostManager 経由。将来削除候補。
   def self.update_joysound_music_post_delivery_deadline_dates
     SongExternalSync.update_joysound_music_post_delivery_deadline_dates
   end

--- a/app/services/joysound_music_post_prioritizer.rb
+++ b/app/services/joysound_music_post_prioritizer.rb
@@ -12,9 +12,11 @@ class JoysoundMusicPostPrioritizer
   private
 
   def unmatched_posts
-    unmatched_urls = JoysoundMusicPost.pluck(:joysound_url) - Song.music_post.pluck(:url)
+    matched_song_exists = Song.music_post
+                              .where(Song.arel_table[:url].eq(JoysoundMusicPost.arel_table[:joysound_url]))
+                              .arel.exists
 
-    JoysoundMusicPost.where(joysound_url: unmatched_urls)
+    JoysoundMusicPost.where.not(matched_song_exists)
   end
 
   def upcoming_posts

--- a/app/services/song_external_sync.rb
+++ b/app/services/song_external_sync.rb
@@ -45,6 +45,7 @@ class SongExternalSync
       JoysoundMusicPostPrioritizer.call
     end
 
+    # DEPRECATED: 実運用は JoysoundMusicPostManager 経由。将来削除候補。
     def refresh_joysound_music_post_song
       browser_manager = BrowserManager.new
       total_count = Song.music_post.count
@@ -86,6 +87,7 @@ class SongExternalSync
       end
     end
 
+    # DEPRECATED: 実運用は JoysoundMusicPostManager 経由。将来削除候補。
     def update_joysound_music_post_delivery_deadline_dates
       music_post_songs = Song.music_post.includes(:song_with_joysound_utasuki)
                              .where.not(song_with_joysound_utasukis: { id: nil })

--- a/app/services/song_external_sync.rb
+++ b/app/services/song_external_sync.rb
@@ -10,14 +10,17 @@ class SongExternalSync
     def fetch_joysound_songs(progress: nil)
       scraper = Scrapers::JoysoundScraper.new
       joysound_songs = JoysoundSong.all
+      existing_joysound_keys = Song.where(karaoke_type: "JOYSOUND").pluck(:title, :url).to_set
 
       Song.process_with_progress(joysound_songs, label: "JOYSOUND楽曲", progress:, progress_options: { status: "JOYSOUND楽曲取得中", label: "JOYSOUND楽曲詳細を取得しています" }) do |record|
         title = record.display_title.split("／").first
-        scraper.scrape_song_page(record.url) unless Song.exists?(title:, url: record.url, karaoke_type: "JOYSOUND")
+        scraper.scrape_song_page(record.url) unless existing_joysound_keys.include?([title, record.url])
       end
 
+      existing_joysound_urls = Song.where(karaoke_type: "JOYSOUND").pluck(:url).to_set
+
       Constants::Karaoke::JOYSOUND_ALLOWLIST.each.with_index(1) do |url, index|
-        next if Song.exists?(url:, karaoke_type: "JOYSOUND")
+        next if existing_joysound_urls.include?(url)
 
         Admin::ProgressReporter.report(
           progress:,
@@ -69,10 +72,10 @@ class SongExternalSync
     def fetch_dam_songs(progress: nil)
       scraper = Scrapers::DamScraper.new
       dam_songs = DamSong.order(created_at: :desc)
+      existing_dam_urls = Song.where(karaoke_type: "DAM").pluck(:url).to_set
 
       Song.process_with_progress(dam_songs, label: "DAM楽曲", progress:, progress_options: { status: "DAM楽曲取得中", label: "DAM楽曲詳細を取得しています" }) do |record|
-        song = Song.includes(:song_with_dam_ouchikaraoke).find_by(karaoke_type: "DAM", url: record.url)
-        next if song.present?
+        next if existing_dam_urls.include?(record.url)
 
         scraper.scrape_song_page(record)
       end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :solid_cache_store
 
   # Use Solid Queue for durable background jobs without Redis/Sidekiq.
   config.active_job.queue_adapter = :solid_queue

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info").to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,14 +25,14 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/db/migrate/20260704224328_create_solid_cache_entries.rb
+++ b/db/migrate/20260704224328_create_solid_cache_entries.rb
@@ -1,0 +1,15 @@
+class CreateSolidCacheEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary :key, limit: 1024, null: false
+      t.binary :value, limit: 536_870_912, null: false
+      t.datetime :created_at, null: false
+      t.integer :key_hash, limit: 8, null: false
+      t.integer :byte_size, limit: 4, null: false
+
+      t.index :byte_size
+      t.index %i[key_hash byte_size], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+      t.index :key_hash, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_020000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_224328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -144,6 +144,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_020000) do
     t.string "short_title", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "song_original_songs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -1,0 +1,174 @@
+require 'test_helper'
+
+module Admin
+  class DashboardControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @dam_artist = create_display_artist(karaoke_type: 'DAM')
+      @joysound_artist = create_display_artist(karaoke_type: 'JOYSOUND')
+      @music_post_artist = create_display_artist(karaoke_type: 'JOYSOUND(うたスキ)')
+
+      @dam_song = create_song(display_artist: @dam_artist, karaoke_type: 'DAM')
+      @joysound_song = create_song(display_artist: @joysound_artist, karaoke_type: 'JOYSOUND')
+      @music_post_song = create_song(display_artist: @music_post_artist, karaoke_type: 'JOYSOUND(うたスキ)')
+
+      # Song with every distribution URL present, to exercise the FILTER aggregation.
+      @fully_linked_song = create_song(
+        display_artist: @dam_artist,
+        karaoke_type: 'DAM',
+        youtube_url: 'https://youtube.example/watch',
+        nicovideo_url: 'https://nicovideo.example/watch',
+        apple_music_url: 'https://music.apple.example/song',
+        youtube_music_url: 'https://music.youtube.example/watch',
+        spotify_url: 'https://spotify.example/track',
+        line_music_url: 'https://music.line.example/track'
+      )
+
+      # Song with explicit empty-string URLs (the DB default), to confirm the boundary
+      # between empty string and a present value is handled identically to the scopes.
+      @empty_url_song = create_song(
+        display_artist: @dam_artist,
+        karaoke_type: 'DAM',
+        youtube_url: '',
+        nicovideo_url: '',
+        apple_music_url: '',
+        youtube_music_url: '',
+        spotify_url: '',
+        line_music_url: ''
+      )
+
+      original_song = create_original_song
+      @linked_song = create_song(display_artist: @dam_artist, karaoke_type: 'DAM')
+      @linked_song.original_songs << original_song
+    end
+
+    test 'renders successfully' do
+      get admin_root_path
+
+      assert_response :success
+    end
+
+    test 'distribution metrics match individually computed scope counts' do
+      get admin_root_path
+
+      assert_response :success
+
+      total = Song.count
+      metrics = distribution_metrics_from_response
+
+      assert_equal Song.dam.count, metrics.fetch('dam').fetch(:value)
+      assert_equal Song.joysound.count, metrics.fetch('joysound').fetch(:value)
+      assert_equal Song.music_post.count, metrics.fetch('music-post').fetch(:value)
+      assert_equal Song.youtube.count, metrics.fetch('youtube').fetch(:value)
+      assert_equal Song.where.not(nicovideo_url: '').count, metrics.fetch('nicovideo').fetch(:value)
+      assert_equal Song.apple_music.count, metrics.fetch('apple').fetch(:value)
+      assert_equal Song.youtube_music.count, metrics.fetch('youtube-music').fetch(:value)
+      assert_equal Song.spotify.count, metrics.fetch('spotify').fetch(:value)
+      assert_equal Song.line_music.count, metrics.fetch('line-music').fetch(:value)
+
+      metrics.each_value { |metric| assert_equal total, metric.fetch(:total) }
+    end
+
+    test 'nicovideo boundary counts exclude empty string urls and include present urls' do
+      get admin_root_path
+
+      assert_response :success
+
+      metrics = distribution_metrics_from_response
+      assert_equal Song.where.not(nicovideo_url: '').count, metrics.fetch('nicovideo').fetch(:value)
+      assert_includes Song.where.not(nicovideo_url: '').pluck(:id), @fully_linked_song.id
+      assert_not_includes Song.where.not(nicovideo_url: '').pluck(:id), @empty_url_song.id
+    end
+
+    test 'karaoke type distribution is zero for a type with no songs' do
+      Song.where(karaoke_type: 'JOYSOUND(うたスキ)').destroy_all
+
+      get admin_root_path
+
+      assert_response :success
+
+      metrics = distribution_metrics_from_response
+      assert_equal 0, metrics.fetch('music-post').fetch(:value)
+      assert_equal Song.music_post.count, metrics.fetch('music-post').fetch(:value)
+    end
+
+    test 'dashboard summary matches individually computed counts' do
+      get admin_root_path
+
+      assert_response :success
+
+      summary = controller.send(:dashboard_summary)
+      assert_equal Song.count, summary.fetch(:total_songs)
+      assert_equal Song.touhou_arrange.count, summary.fetch(:linked_songs)
+      assert_equal Song.missing_original_songs.count, summary.fetch(:missing_songs)
+      assert_equal OriginalSong.count, summary.fetch(:original_songs)
+      assert_equal DisplayArtist.count, summary.fetch(:display_artists)
+      assert_equal Circle.count, summary.fetch(:circles)
+    end
+
+    test 'insight groups match individually computed counts' do
+      get admin_root_path
+
+      assert_response :success
+
+      groups = controller.send(:insight_groups)
+      data_status_metrics = groups.find { |group| group[:label] == 'データ状態' }.fetch(:metrics)
+      assert_equal Song.count, data_status_metrics.find { |metric| metric[:label] == '総楽曲数' }.fetch(:value)
+      assert_equal Song.with_original_songs.count, data_status_metrics.find { |metric| metric[:label] == '原曲紐付け済み' }.fetch(:value)
+      assert_equal Song.missing_original_songs.count, data_status_metrics.find { |metric| metric[:label] == '原曲未紐付け' }.fetch(:value)
+
+      master_data_metrics = groups.find { |group| group[:label] == 'マスタデータ' }.fetch(:metrics)
+      assert_equal OriginalSong.count, master_data_metrics.find { |metric| metric[:label] == '原曲' }.fetch(:value)
+      assert_equal Circle.count, master_data_metrics.find { |metric| metric[:label] == 'サークル' }.fetch(:value)
+      assert_equal DisplayArtist.count, master_data_metrics.find { |metric| metric[:label] == 'アーティスト' }.fetch(:value)
+
+      music_post_metrics = groups.find { |group| group[:label] == 'ミュージックポスト' }.fetch(:metrics)
+      assert_equal Song.music_post.count, music_post_metrics.find { |metric| metric[:label] == '配信曲' }.fetch(:value)
+      assert_equal Song.music_post.with_original_songs.count, music_post_metrics.find { |metric| metric[:label] == '原曲紐付け済み' }.fetch(:value)
+    end
+
+    test 'distribution and shared summary counts are issued exactly once per request' do
+      sql = capture_sql { get admin_root_path }
+
+      assert_response :success
+
+      # distribution_metrics: karaoke_type breakdown consolidated into a single GROUP BY.
+      group_by_karaoke_type = sql.select { |statement| statement.include?('GROUP BY "songs"."karaoke_type"') }
+      assert_equal 1, group_by_karaoke_type.size, "expected a single karaoke_type GROUP BY query, got: #{group_by_karaoke_type}"
+
+      # distribution_metrics: total + per-service FILTER counts consolidated into one query.
+      filter_aggregate = sql.select { |statement| statement.include?('COUNT(*) FILTER') }
+      assert_equal 1, filter_aggregate.size, "expected a single FILTER aggregate query, got: #{filter_aggregate}"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE youtube_url <> '')"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE nicovideo_url <> '')"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE apple_music_url <> '')"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE youtube_music_url <> '')"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE spotify_url <> '')"
+      assert_includes filter_aggregate.first, "COUNT(*) FILTER (WHERE line_music_url <> '')"
+
+      # dashboard_summary / insight_groups share the same memoized counts, so each of these
+      # should be issued only once despite being referenced from two different methods.
+      missing_original_songs_queries = sql.select { |statement| statement.include?('"songs_original_songs"."id" IS NULL') }
+      assert_equal 1, missing_original_songs_queries.size, "expected missing_original_songs to be memoized, got: #{missing_original_songs_queries}"
+    end
+
+    private
+
+    def distribution_metrics_from_response
+      controller.send(:distribution_metrics).index_by { |metric| metric.fetch(:key) }
+    end
+
+    def capture_sql
+      statements = []
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+        payload = args.last
+        next if payload[:name].in?(%w[SCHEMA TRANSACTION])
+
+        statements << payload[:sql].squish
+      end
+      yield
+      statements
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+  end
+end

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -151,7 +151,61 @@ module Admin
       assert_equal 1, missing_original_songs_queries.size, "expected missing_original_songs to be memoized, got: #{missing_original_songs_queries}"
     end
 
+    test 'dashboard counts are served from cache on subsequent requests' do
+      with_cache_store(ActiveSupport::Cache::MemoryStore.new) do
+        first_sql = capture_sql { get admin_root_path }
+        assert_response :success
+
+        # 初回リクエストで集計クエリが発行され、キャッシュへ書き込まれる。
+        assert_equal 1, count_matching(first_sql, 'GROUP BY "songs"."karaoke_type"')
+        assert_equal 1, count_matching(first_sql, 'COUNT(*) FILTER')
+
+        second_sql = capture_sql { get admin_root_path }
+        assert_response :success
+
+        # 2回目はキャッシュヒットのため COUNT 系集計クエリが再発行されない。
+        assert_equal 0, count_matching(second_sql, 'GROUP BY "songs"."karaoke_type"')
+        assert_equal 0, count_matching(second_sql, 'COUNT(*) FILTER')
+      end
+    end
+
+    test 'cached counts match individually computed values' do
+      with_cache_store(ActiveSupport::Cache::MemoryStore.new) do
+        get admin_root_path
+        assert_response :success
+
+        cached = Rails.cache.fetch('admin:dashboard:v1')
+        assert_equal Song.count, cached.fetch(:total_songs)
+        assert_equal Song.touhou_arrange.count, cached.fetch(:linked_songs)
+        assert_equal Song.missing_original_songs.count, cached.fetch(:missing_original_songs)
+        assert_equal Song.with_original_songs.count, cached.fetch(:with_original_songs)
+        assert_equal Song.music_post.with_original_songs.count, cached.fetch(:music_post_with_original_songs)
+        assert_equal OriginalSong.count, cached.fetch(:original_songs)
+        assert_equal DisplayArtist.count, cached.fetch(:display_artists)
+        assert_equal Circle.count, cached.fetch(:circles)
+        assert_equal Original.count, cached.fetch(:originals)
+        assert_equal KaraokeDeliveryModel.count, cached.fetch(:karaoke_delivery_models)
+        assert_equal JoysoundMusicPost.count, cached.fetch(:joysound_music_posts)
+        assert_equal Song.count, cached.fetch(:distribution_service_counts).fetch(:total)
+        assert_equal Song.youtube.count, cached.fetch(:distribution_service_counts).fetch(:youtube)
+        assert_equal Song.group(:karaoke_type).count, cached.fetch(:karaoke_type_counts)
+      end
+    end
+
     private
+
+    def count_matching(statements, fragment)
+      statements.count { |statement| statement.include?(fragment) }
+    end
+
+    def with_cache_store(store)
+      original = Rails.cache
+      Rails.cache = store
+      yield
+    ensure
+      store.clear
+      Rails.cache = original
+    end
 
     def distribution_metrics_from_response
       controller.send(:distribution_metrics).index_by { |metric| metric.fetch(:key) }

--- a/test/models/concerns/parallel_processor_test.rb
+++ b/test/models/concerns/parallel_processor_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class ParallelProcessorTest < ActiveSupport::TestCase
+  class DummyProcessor
+    include ParallelProcessor
+  end
+
+  teardown do
+    ENV.delete('SCRAPING_THREAD_COUNT')
+  end
+
+  test '既定（スレッド数1）では各要素を順序通りに1回ずつ処理し、進捗の最終currentが要素数と一致する' do
+    records = [1, 2, 3, 4, 5]
+    processed = []
+    progress_calls = []
+    progress = ->(**attrs) { progress_calls << attrs }
+
+    DummyProcessor.process_with_progress(records, progress:) do |record|
+      processed << record
+    end
+
+    assert_equal records, processed
+    assert_equal records.size, progress_calls.last[:current]
+    assert_equal records.size, progress_calls.last[:total]
+  end
+
+  test 'SCRAPING_THREAD_COUNT>1では各要素がちょうど1回ずつ処理され、進捗の最終currentが要素数と一致する' do
+    ENV['SCRAPING_THREAD_COUNT'] = '3'
+    records = (1..20).to_a
+    mutex = Mutex.new
+    processed = []
+    progress_calls = []
+    progress = ->(**attrs) { mutex.synchronize { progress_calls << attrs } }
+
+    DummyProcessor.process_with_progress(records, progress:) do |record|
+      mutex.synchronize { processed << record }
+    end
+
+    assert_equal records.sort, processed.sort
+    assert_equal records.size, processed.size
+    assert_equal records.size, progress_calls.last[:current]
+    assert_equal records.size, progress_calls.last[:total]
+  end
+
+  test 'total_countが0のときは早期returnし、reporter.startがtotal:0で呼ばれる' do
+    progress_calls = []
+    progress = ->(**attrs) { progress_calls << attrs }
+
+    DummyProcessor.process_with_progress([], progress:) { |_record| flunk 'yieldされてはならない' }
+
+    assert_equal 1, progress_calls.size
+    assert_equal 0, progress_calls.first[:current]
+    assert_equal 0, progress_calls.first[:total]
+  end
+
+  test 'ActiveRecord::Relationでも既定（スレッド数1）で各レコードを1回ずつ処理する' do
+    artists = Array.new(3) { create_display_artist }
+    relation = DisplayArtist.where(id: artists.map(&:id))
+    processed = []
+    progress_calls = []
+    progress = ->(**attrs) { progress_calls << attrs }
+
+    DummyProcessor.process_with_progress(relation, progress:) do |record|
+      processed << record
+    end
+
+    assert_equal artists.sort_by(&:id), processed.sort_by(&:id)
+    assert_equal artists.size, progress_calls.last[:current]
+    assert_equal artists.size, progress_calls.last[:total]
+  end
+
+  test 'ActiveRecord::RelationでもSCRAPING_THREAD_COUNT>1で各レコードがちょうど1回ずつ処理される' do
+    ENV['SCRAPING_THREAD_COUNT'] = '3'
+    artists = Array.new(10) { create_display_artist }
+    relation = DisplayArtist.where(id: artists.map(&:id))
+    mutex = Mutex.new
+    processed = []
+
+    DummyProcessor.process_with_progress(relation, progress: ->(**_attrs) {}) do |record|
+      mutex.synchronize { processed << record }
+    end
+
+    assert_equal artists.map(&:id).sort, processed.map(&:id).sort
+    assert_equal artists.size, processed.size
+  end
+end


### PR DESCRIPTION
## 概要

パフォーマンス改善のための調査を行い、破壊的変更なし・段階的導入・容易なロールバックを大前提に改善を実施しました。全変更でテスト緑（373 runs, 0 failures）・RuboCop クリーンです。

**スクレイピングの並列化は別PRとします**（実ブラウザ・実サイトでの検証が必要なため）。本PRにはその土台となる進捗並列化バグ修正までを含みます。

## 実測効果（ダッシュボード）

同一DBでダッシュボード1回表示あたりの集計SELECT数を計測:

| | 集計SELECT数 |
|---|---|
| 改善前 | 47本 |
| 改善後・キャッシュミス（初回/5分毎） | 24本（約49%減） |
| 改善後・キャッシュヒット（以降5分間） | 0本（100%減） |

## 変更内容

### デッドコード整理
- 未使用の `Song.not_set_original_song` を削除、レガシーメソッドに DEPRECATED コメントを追加

### インフラ設定
- 本番ログレベルを `:debug` → `info`（`RAILS_LOG_LEVEL` で上書き可）
- Puma マルチワーカー（クラスタモード + `preload_app!`）を有効化（`WEB_CONCURRENCY` で調整）
- solid_cache を導入し本番キャッシュストアを設定（primary DB にテーブル追加のみ・既存データ不変）

### ダッシュボード
- COUNTクエリを集約（`Song.count` の9回重複解消、種別分布9本→1本、配信有無6本→1本）
- 全集計を低レベルキャッシュ化（`admin:dashboard:v1`, 5分TTL）。表示値の一致を専用テストで検証

### クエリ最適化
- 未マッチ MusicPost 抽出を全件pluck差分 → SQL反結合（NOT EXISTS）に
- TSVインポートをトランザクションで囲み原子性を確保
- スクレイピングのループ内存在チェックを事前集合(Set)化、無駄な includes 除去

### スクレイピング並列化の土台
- 進捗表示付き処理で並列実行が無効化されるバグを修正（in_threads 方式・Mutex 保護）
- 専用の `SCRAPING_THREAD_COUNT`（既定1=逐次、現状と完全同一挙動）で opt-in する形。実際の並列有効化はブラウザのスレッド毎割り当て実装＋実環境検証の後（別PR）

## テスト計画
- [x] `devbox run test` 全体緑（373 runs, 2896 assertions, 0 failures）
- [x] `devbox run rubocop` offense 0

## 補足（未対応・別途）
- スクレイピングの実並列化（スレッド毎ブラウザ割り当て・sleep調整・ブラウザ再利用）は実環境検証とセットで別PR
- sourcemap 本番配信除外はビルドパイプライン依存・効果限定のため見送り
- 孤立テーブル `song_original_songs` は未使用だが DROP はせず記録に留め（将来対応）