### PR TITLE
feat: スクレイピングの実並列化（スレッド毎ブラウザ・レート制御・堅牢化）

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,8 @@ Style/SignalException:
 Metrics/ModuleLength:
   Exclude:
     - app/models/concerns/parallel_processor.rb
+
+# 指数バックオフ用の引数(base_delay/max_delay/jitter)追加でパラメータ数が増えたため許容
+Metrics/ParameterLists:
+  Exclude:
+    - app/models/concerns/retryable.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,8 @@ Metrics/ModuleLength:
     - app/models/concerns/parallel_processor.rb
 
 # 指数バックオフ用の引数(base_delay/max_delay/jitter)追加でパラメータ数が増えたため許容
+# スレッド毎ワーカー(worker_factory/worker_teardown)追加でパラメータ数が増えたため許容
 Metrics/ParameterLists:
   Exclude:
     - app/models/concerns/retryable.rb
+    - app/models/concerns/parallel_processor.rb

--- a/app/models/concerns/parallel_processor.rb
+++ b/app/models/concerns/parallel_processor.rb
@@ -8,9 +8,11 @@ module ParallelProcessor
   DEFAULT_BATCH_SIZE = 1000
   DEFAULT_PROCESS_COUNT = ENV.fetch('PARALLEL_PROCESS_COUNT', 7).to_i
   # サーバー進捗表示付き処理（process_with_server_progress）専用のスレッド数。
-  # PARALLEL_PROCESS_COUNT とは独立させ、既定は1（逐次実行）にしている。
-  # スクレイパ/ブラウザがまだスレッド安全でないため、既定で並列化されないようにするため。
-  DEFAULT_PROGRESS_THREAD_COUNT = 1
+  # PARALLEL_PROCESS_COUNT とは独立させている。
+  # スレッド毎のブラウザ割り当て・ブラウザ再利用・レート制御相当のクランプ・エラー継続を
+  # 実装済みのため、既定を3並列にしている。コネクションプールサイズ（RAILS_MAX_THREADS、既定5）を
+  # 超えないよう progress_thread_count でクランプする。SCRAPING_THREAD_COUNT 環境変数で上書き可能。
+  DEFAULT_PROGRESS_THREAD_COUNT = 3
   # continue_on_error: true 時、連続でこの件数だけ失敗が続いたら安全のため処理を打ち切る（既定値）。
   DEFAULT_CONSECUTIVE_FAILURE_LIMIT = 10
 

--- a/app/models/concerns/parallel_processor.rb
+++ b/app/models/concerns/parallel_processor.rb
@@ -55,10 +55,12 @@ module ParallelProcessor
     # @param collection [Array, ActiveRecord::Relation] 処理対象のコレクション
     # @param label [String] ログに表示するラベル
     # @param options [Hash] オプション（batch_size, process_count）
-    # @yield [record] 各レコードに対する処理
-    def process_with_progress(collection, label: nil, progress: nil, progress_options: {}, **, &)
+    # @param worker_factory [Proc, nil] スレッド毎の専用ワーカーを生成するProc（例: -> { Scraper.new }）
+    # @param worker_teardown [Proc, nil] worker_factoryが生成したワーカーを後始末するProc
+    # @yield [record, worker] 各レコードに対する処理（workerはworker_factory未指定ならnil）
+    def process_with_progress(collection, label: nil, progress: nil, progress_options: {}, worker_factory: nil, worker_teardown: nil, **, &)
       if progress
-        process_with_server_progress(collection, progress:, label:, progress_options:, &)
+        process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory:, worker_teardown:, &)
         return
       end
 
@@ -71,7 +73,7 @@ module ParallelProcessor
 
     private
 
-    def process_with_server_progress(collection, progress:, label:, progress_options:)
+    def process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory: nil, worker_teardown: nil, &)
       total_count = collection_total_count(collection)
       reporter = Admin::ProgressReporter.new(
         progress:,
@@ -91,24 +93,51 @@ module ParallelProcessor
         end
       end
 
-      if thread_count > 1
-        # SCRAPING_THREAD_COUNT>1 で並列実行するには、yield されるブロック内の処理（スクレイパ/ブラウザ）が
-        # スレッド安全である必要がある。ブラウザ再利用のスレッド毎割り当てが未実装のため、既定値は1（逐次）。
-        records = collection.respond_to?(:to_a) ? collection.to_a : collection
-        Parallel.each(records, in_threads: thread_count) do |record|
-          yield(record)
-          advance.call
+      pool = WorkerPool.new(worker_factory, worker_teardown)
+      begin
+        if thread_count > 1
+          process_in_parallel_batches(collection, thread_count:, pool:, advance:, &)
+        else
+          each_collection_record(collection) do |record|
+            yield(record, pool.worker_for_current_thread)
+            advance.call
+          end
         end
-      else
-        each_collection_record(collection) do |record|
-          yield(record)
+      ensure
+        pool.shutdown
+      end
+    end
+
+    # 並列分岐: バッチ単位で読み出し、バッチ内をスレッドで並列処理する。
+    # collectionを一括でto_aせず、メモリ使用量をバッチサイズに抑える。
+    def process_in_parallel_batches(collection, thread_count:, pool:, advance:)
+      each_parallel_batch(collection) do |batch|
+        Parallel.each(batch, in_threads: thread_count) do |record|
+          Rails.application.executor.wrap do
+            ActiveRecord::Base.connection_pool.with_connection do
+              yield(record, pool.worker_for_current_thread)
+            end
+          end
           advance.call
         end
       end
     end
 
+    # collectionをバッチ単位（DEFAULT_BATCH_SIZE件ずつ）でyieldする。
+    # ActiveRecord::Relationはfind_in_batchesで、それ以外はeach_sliceでバッチ化する。
+    def each_parallel_batch(collection, &)
+      if collection.respond_to?(:find_in_batches)
+        collection.find_in_batches(batch_size: DEFAULT_BATCH_SIZE, &)
+      else
+        collection.each_slice(DEFAULT_BATCH_SIZE, &)
+      end
+    end
+
+    # SCRAPING_THREAD_COUNTで指定されたスレッド数を、ActiveRecordのコネクションプールサイズで
+    # 上限クランプする（ActiveRecord::ConnectionTimeoutError防止）。最低1は保証する。
     def progress_thread_count
-      ENV.fetch('SCRAPING_THREAD_COUNT', DEFAULT_PROGRESS_THREAD_COUNT).to_i
+      configured_count = ENV.fetch('SCRAPING_THREAD_COUNT', DEFAULT_PROGRESS_THREAD_COUNT).to_i
+      configured_count.clamp(1, ActiveRecord::Base.connection_pool.size)
     end
 
     def collection_total_count(collection)

--- a/app/models/concerns/parallel_processor.rb
+++ b/app/models/concerns/parallel_processor.rb
@@ -11,6 +11,8 @@ module ParallelProcessor
   # PARALLEL_PROCESS_COUNT とは独立させ、既定は1（逐次実行）にしている。
   # スクレイパ/ブラウザがまだスレッド安全でないため、既定で並列化されないようにするため。
   DEFAULT_PROGRESS_THREAD_COUNT = 1
+  # continue_on_error: true 時、連続でこの件数だけ失敗が続いたら安全のため処理を打ち切る（既定値）。
+  DEFAULT_CONSECUTIVE_FAILURE_LIMIT = 10
 
   class_methods do
     # バッチ処理で並列実行を行う
@@ -57,23 +59,28 @@ module ParallelProcessor
     # @param options [Hash] オプション（batch_size, process_count）
     # @param worker_factory [Proc, nil] スレッド毎の専用ワーカーを生成するProc（例: -> { Scraper.new }）
     # @param worker_teardown [Proc, nil] worker_factoryが生成したワーカーを後始末するProc
+    # @param continue_on_error [Boolean] trueの場合、1レコードの失敗（例外）を握り潰してログ記録し処理を継続する。
+    #   ただし連続失敗が閾値（SCRAPING_CONSECUTIVE_FAILURE_LIMIT）に達すると安全のため打ち切る。
     # @yield [record, worker] 各レコードに対する処理（workerはworker_factory未指定ならnil）
-    def process_with_progress(collection, label: nil, progress: nil, progress_options: {}, worker_factory: nil, worker_teardown: nil, **, &)
-      if progress
-        process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory:, worker_teardown:, &)
-        return
-      end
+    # @return [Hash, nil] continue_on_error: true の場合は失敗集約情報（failed_count, failures, stopped）。false の場合はnil。
+    def process_with_progress(collection, label: nil, progress: nil, progress_options: {}, worker_factory: nil, worker_teardown: nil, continue_on_error: false, **, &)
+      return process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory:, worker_teardown:, continue_on_error:, &) if progress
 
       progress_logger = create_progress_logger(label)
 
       process_in_parallel(collection, progress_logger:, **) do |record, _index|
-        yield(record)
+        if continue_on_error
+          rescue_and_log_failure(record, label:) { yield(record) }
+        else
+          yield(record)
+        end
       end
+      nil
     end
 
     private
 
-    def process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory: nil, worker_teardown: nil, &)
+    def process_with_server_progress(collection, progress:, label:, progress_options:, worker_factory: nil, worker_teardown: nil, continue_on_error: false, &)
       total_count = collection_total_count(collection)
       reporter = Admin::ProgressReporter.new(
         progress:,
@@ -93,34 +100,101 @@ module ParallelProcessor
         end
       end
 
+      failure_tracker = continue_on_error ? ParallelProcessor::FailureTracker.new(limit: consecutive_failure_limit) : nil
+
       pool = WorkerPool.new(worker_factory, worker_teardown)
       begin
         if thread_count > 1
-          process_in_parallel_batches(collection, thread_count:, pool:, advance:, &)
+          process_in_parallel_batches(collection, thread_count:, pool:, advance:, failure_tracker:, label:, &)
         else
           each_collection_record(collection) do |record|
-            yield(record, pool.worker_for_current_thread)
+            break if failure_tracker&.stopped?
+
+            guarded_call(record, failure_tracker, label:) { yield(record, pool.worker_for_current_thread) }
             advance.call
           end
         end
       ensure
         pool.shutdown
       end
+
+      failure_tracker&.summary
     end
 
     # 並列分岐: バッチ単位で読み出し、バッチ内をスレッドで並列処理する。
     # collectionを一括でto_aせず、メモリ使用量をバッチサイズに抑える。
-    def process_in_parallel_batches(collection, thread_count:, pool:, advance:)
+    def process_in_parallel_batches(collection, thread_count:, pool:, advance:, failure_tracker: nil, label: nil)
       each_parallel_batch(collection) do |batch|
+        break if failure_tracker&.stopped?
+
         Parallel.each(batch, in_threads: thread_count) do |record|
+          next if failure_tracker&.stopped?
+
           Rails.application.executor.wrap do
             ActiveRecord::Base.connection_pool.with_connection do
-              yield(record, pool.worker_for_current_thread)
+              guarded_call(record, failure_tracker, label:) { yield(record, pool.worker_for_current_thread) }
             end
           end
           advance.call
         end
       end
+    end
+
+    # failure_tracker未指定なら素通しでブロックを実行する（continue_on_error: false と同じ挙動）。
+    # 指定時は例外を握り潰して失敗を集約し、次のレコードの処理に進めるようにする。
+    def guarded_call(record, failure_tracker, label:)
+      return yield unless failure_tracker
+
+      begin
+        yield
+        failure_tracker.record_success
+      rescue StandardError => e
+        newly_stopped = failure_tracker.record_failure(record_identifier(record), e)
+        log_scraping_failure(record, e, label:)
+        log_consecutive_failure_stop(label:) if newly_stopped
+      end
+    end
+
+    # continue_on_error用の軽量版rescue（process_in_parallelのマルチプロセス分岐向け）。
+    # プロセスをforkするため状態共有ができず、連続失敗による早期打ち切りはサポートしない。
+    def rescue_and_log_failure(record, label:)
+      yield
+    rescue StandardError => e
+      log_scraping_failure(record, e, label:)
+    end
+
+    def record_identifier(record)
+      record.respond_to?(:id) ? record.id : record.inspect
+    end
+
+    # レコード単位の失敗をログ記録する（継続する旨も明示する）。
+    # Admin::OperationLogger.log は内部でRails.loggerに書き出すため、二重ログにならないよう
+    # 個別のRails.logger呼び出しは行わない（JoysoundMusicPostManagerの既存の使い方に合わせている）。
+    def log_scraping_failure(record, error, label:)
+      Admin::OperationLogger.log(
+        level: :error,
+        event: :parallel_processing,
+        action: :record_error,
+        resource: label || :record,
+        id: record_identifier(record),
+        error: error.message,
+        continued: true
+      )
+    end
+
+    def log_consecutive_failure_stop(label:)
+      Admin::OperationLogger.log(
+        level: :error,
+        event: :parallel_processing,
+        action: :aborted,
+        resource: label || :record,
+        reason: "連続#{consecutive_failure_limit}件の失敗のため処理を中断しました"
+      )
+    end
+
+    # SCRAPING_CONSECUTIVE_FAILURE_LIMITで指定された、連続失敗による打ち切り閾値。
+    def consecutive_failure_limit
+      ENV.fetch('SCRAPING_CONSECUTIVE_FAILURE_LIMIT', DEFAULT_CONSECUTIVE_FAILURE_LIMIT).to_i
     end
 
     # collectionをバッチ単位（DEFAULT_BATCH_SIZE件ずつ）でyieldする。

--- a/app/models/concerns/parallel_processor/failure_tracker.rb
+++ b/app/models/concerns/parallel_processor/failure_tracker.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ParallelProcessor
+  # continue_on_error: true 時に、レコード単位の失敗を集約し、
+  # 連続失敗数が閾値に達したら安全に処理を打ち切るためのトラッカー。
+  #
+  # 複数スレッドから同時に呼ばれるため、状態変更は全てMutexで保護する。
+  class FailureTracker
+    # @param limit [Integer] 連続失敗がこの件数に達すると打ち切りを決定する
+    def initialize(limit:)
+      @limit = limit
+      @mutex = Mutex.new
+      @failures = []
+      @consecutive_failures = 0
+      @stopped = false
+    end
+
+    # 既に打ち切りが決定しているか
+    def stopped?
+      @mutex.synchronize { @stopped }
+    end
+
+    # 成功を記録し、連続失敗カウンタをリセットする
+    def record_success
+      @mutex.synchronize { @consecutive_failures = 0 }
+    end
+
+    # 失敗を記録する。この呼び出しで連続失敗数が閾値に達し、新たに打ち切りが決定した場合はtrueを返す。
+    def record_failure(identifier, error)
+      @mutex.synchronize do
+        @failures << { record: identifier, error: error.message }
+        @consecutive_failures += 1
+        next false if @stopped || @consecutive_failures < @limit
+
+        @stopped = true
+      end
+    end
+
+    # 集約結果のサマリを返す
+    def summary
+      @mutex.synchronize { { failed_count: @failures.size, failures: @failures.dup, stopped: @stopped } }
+    end
+  end
+end

--- a/app/models/concerns/parallel_processor/worker_pool.rb
+++ b/app/models/concerns/parallel_processor/worker_pool.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ParallelProcessor
+  # スレッド毎の専用ワーカー（例: 専用ブラウザを持つスクレイパ）を生成・追跡し、
+  # 処理完了後にまとめて後始末するためのプール。
+  #
+  # スレッドローカルのキーはプールのインスタンス毎にユニークにしている。こうしないと、
+  # 逐次実行（メインスレッドのみで動く）で生成したワーカーが、次回のプール生成後も
+  # メインスレッドのスレッドローカル領域に残ってしまい、誤って再利用されてしまう。
+  class WorkerPool
+    # @param factory [Proc, nil] ワーカーを生成するProc（例: -> { Scraper.new }）。nilならワーカーを使わない。
+    # @param teardown [Proc, nil] ワーカーを後始末するProc（例: ->(worker) { worker.browser.quit }）。
+    def initialize(factory, teardown)
+      @factory = factory
+      @teardown = teardown
+      @workers = []
+      @mutex = Mutex.new
+      @thread_local_key = "parallel_worker_pool_#{object_id}"
+    end
+
+    # 現在のスレッド用のワーカーを返す。同一スレッドからの呼び出しでは同じワーカーを再利用する。
+    # factory未指定ならnilを返す（ワーカーを使わない後方互換のパス）。
+    def worker_for_current_thread
+      return nil unless @factory
+
+      Thread.current[@thread_local_key] ||= build_and_track_worker
+    end
+
+    # 追跡している全ワーカーを後始末する。個々のteardownが例外を投げても、
+    # 残りのワーカーの後始末は継続する。teardown未指定なら何もしない。
+    def shutdown
+      workers = @mutex.synchronize { @workers.dup }
+      workers.each { |worker| teardown_worker(worker) } if @teardown
+    ensure
+      @mutex.synchronize { @workers.clear }
+      Thread.current[@thread_local_key] = nil
+    end
+
+    private
+
+    def build_and_track_worker
+      worker = @factory.call
+      @mutex.synchronize { @workers << worker }
+      worker
+    end
+
+    def teardown_worker(worker)
+      @teardown.call(worker)
+    rescue StandardError => e
+      Rails.logger.warn("ParallelProcessor::WorkerPool: ワーカーの後始末に失敗しました: #{e.message}")
+    end
+  end
+end

--- a/app/models/concerns/retryable.rb
+++ b/app/models/concerns/retryable.rb
@@ -9,7 +9,8 @@ module Retryable
     Ferrum::TimeoutError,
     Ferrum::PendingConnectionsError,
     Ferrum::StatusError,
-    Ferrum::NodeNotFoundError
+    Ferrum::NodeNotFoundError,
+    Ferrum::DeadBrowserError
   ].freeze
 
   class_methods do
@@ -17,7 +18,10 @@ module Retryable
     # @param max_retries [Integer] 最大リトライ回数（デフォルト: 3）
     # @param errors [Array<Class>] リトライ対象のエラークラス
     # @param on_retry [Proc] リトライ時に実行する処理
-    def with_retry(max_retries: 3, errors: RETRYABLE_ERRORS, on_retry: nil)
+    # @param base_delay [Float] バックオフの基準待機秒数（デフォルト: 0.5）
+    # @param max_delay [Float] バックオフの最大待機秒数（デフォルト: 8.0）
+    # @param jitter [Float] 待機秒数に加える揺らぎの比率（デフォルト: 0.5）
+    def with_retry(max_retries: 3, errors: RETRYABLE_ERRORS, on_retry: nil, base_delay: 0.5, max_delay: 8.0, jitter: 0.5)
       retry_count = 0
       begin
         yield
@@ -30,13 +34,15 @@ module Retryable
 
         Rails.logger.warn("Retry #{retry_count}/#{max_retries} due to #{e.class}: #{e.message}")
         on_retry&.call(e, retry_count)
+        delay = [base_delay * (2**(retry_count - 1)), max_delay].min
+        sleep(delay + (rand * jitter * delay))
         retry
       end
     end
   end
 
   # インスタンスメソッドとしても使えるように
-  def with_retry(max_retries: 3, errors: RETRYABLE_ERRORS, on_retry: nil, &)
-    self.class.with_retry(max_retries:, errors:, on_retry:, &)
+  def with_retry(max_retries: 3, errors: RETRYABLE_ERRORS, on_retry: nil, base_delay: 0.5, max_delay: 8.0, jitter: 0.5, &)
+    self.class.with_retry(max_retries:, errors:, on_retry:, base_delay:, max_delay:, jitter:, &)
   end
 end

--- a/app/services/browser_manager.rb
+++ b/app/services/browser_manager.rb
@@ -59,11 +59,14 @@ class BrowserManager
   end
 
   # ページにアクセスして安定するまで待機
+  # ScrapingRateLimiter を通すことで、相手サイトへの実効QPSをスレッド数に依存させず一定に保つ
   def visit(url, wait_duration: 1.0)
     raise 'Browser not started' unless @browser
 
-    @browser.goto(url)
-    @browser.network.wait_for_idle(duration: wait_duration, timeout: @options[:timeout])
+    ScrapingRateLimiter.throttle(url) do
+      @browser.goto(url)
+      @browser.network.wait_for_idle(duration: wait_duration, timeout: @options[:timeout])
+    end
   end
 
   # CSSセレクタで要素を取得

--- a/app/services/browser_manager.rb
+++ b/app/services/browser_manager.rb
@@ -5,22 +5,57 @@ class BrowserManager
   DEFAULT_OPTIONS = {
     timeout: 10,
     window_size: [1440, 900],
-    browser_options: { 'no-sandbox': nil }
+    browser_options: { 'no-sandbox': nil, 'disk-cache-size': '1', 'disable-application-cache': nil }
   }.freeze
 
   attr_reader :browser, :options
 
-  def initialize(custom_options = {})
+  def initialize(custom_options = {}, persistent: false)
     @options = DEFAULT_OPTIONS.merge(custom_options)
     @browser = nil
+    @persistent = persistent
   end
 
   # ブラウザを起動してブロックを実行
+  # persistent: true の場合、ブラウザを終了せず再利用する（呼び出し側が close/restart で後始末する）
   def with_browser
+    return yield(@browser) if @persistent && started?
+
     start_browser
     yield(@browser)
   ensure
+    quit_browser unless @persistent
+  end
+
+  # ブラウザが起動済みかどうか
+  def started?
+    !@browser.nil?
+  end
+
+  # 永続モードかどうか
+  def persistent?
+    @persistent
+  end
+
+  # 永続ブラウザを明示的に終了する（プールの後始末用）
+  def close
     quit_browser
+  end
+
+  # Chromeプロセスごと起動し直す（メモリ・キャッシュを完全に解放したい場合）
+  def restart
+    quit_browser
+    start_browser
+  end
+
+  # cookie・localStorage・セッション状態、およびネットワークトラフィックの記録をクリアする
+  # 未起動時は何もしない
+  def reset_session
+    return unless started?
+
+    # browser.reset は Context を作り直して cookie 等をクリアする（Ferrum 標準API）
+    @browser.reset
+    @browser.network.clear(:traffic)
   end
 
   # ページにアクセスして安定するまで待機
@@ -28,7 +63,7 @@ class BrowserManager
     raise 'Browser not started' unless @browser
 
     @browser.goto(url)
-    @browser.network.wait_for_idle(duration: wait_duration)
+    @browser.network.wait_for_idle(duration: wait_duration, timeout: @options[:timeout])
   end
 
   # CSSセレクタで要素を取得

--- a/app/services/joysound_music_post_manager.rb
+++ b/app/services/joysound_music_post_manager.rb
@@ -54,7 +54,6 @@ class JoysoundMusicPostManager
 
   # 楽曲の取得処理（改善版）
   def fetch_songs_with_progress(progress: nil)
-    scraper = Scrapers::JoysoundScraper.new
     prioritized_posts = JoysoundMusicPostPrioritizer.call
 
     Rails.logger.info("Starting JOYSOUND music post song fetch: #{prioritized_posts.count} posts")
@@ -63,8 +62,10 @@ class JoysoundMusicPostManager
       prioritized_posts,
       label: "ミュージックポスト",
       progress:,
-      progress_options: { status: "ミュージックポスト楽曲取得中", label: "ミュージックポスト楽曲を取得しています" }
-    ) do |record|
+      progress_options: { status: "ミュージックポスト楽曲取得中", label: "ミュージックポスト楽曲を取得しています" },
+      worker_factory: -> { Scrapers::JoysoundScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
+      worker_teardown: ->(w) { w.shutdown }
+    ) do |record, scraper|
       process_music_post_record(scraper, record)
     end
 

--- a/app/services/scrapers/base_scraper.rb
+++ b/app/services/scrapers/base_scraper.rb
@@ -35,6 +35,8 @@ module Scrapers
     # 永続ブラウザが再利用されている場合にのみ意味を持つ（非永続モードでは常に安全なno-op）
     # 呼び出し配線（各scrapeメソッド末尾など）は利用側で行う
     def track_browser_use
+      return unless @browser_manager&.persistent?
+
       @browser_manager.reset_session
       @browser_use_count += 1
 

--- a/app/services/scrapers/base_scraper.rb
+++ b/app/services/scrapers/base_scraper.rb
@@ -4,10 +4,19 @@ module Scrapers
   class BaseScraper
     include Retryable
 
+    # 永続ブラウザを再生成するまでに許容する処理件数（メモリ・キャッシュ肥大対策）
+    SCRAPING_BROWSER_MAX_USES = ENV.fetch('SCRAPING_BROWSER_MAX_USES', 50).to_i
+
     def initialize(browser_manager: BrowserManager.new, delivery_model_manager: DeliveryModelManager.instance)
       @browser_manager = browser_manager
       @delivery_model_manager = delivery_model_manager
+      @browser_use_count = 0
       load_selectors
+    end
+
+    # 永続ブラウザを終了する（ワーカープールの後始末用）
+    def shutdown
+      @browser_manager&.close
     end
 
     protected
@@ -19,7 +28,20 @@ module Scrapers
     end
 
     def reset_browser_manager(timeout: 10, process_timeout: 10)
-      @browser_manager = BrowserManager.new(timeout:, process_timeout:)
+      @browser_manager = BrowserManager.new({ timeout:, process_timeout: }, persistent: @browser_manager&.persistent?)
+    end
+
+    # 処理件数をカウントし、上限に達したらChromeプロセスごと作り直す
+    # 永続ブラウザが再利用されている場合にのみ意味を持つ（非永続モードでは常に安全なno-op）
+    # 呼び出し配線（各scrapeメソッド末尾など）は利用側で行う
+    def track_browser_use
+      @browser_manager.reset_session
+      @browser_use_count += 1
+
+      return unless @browser_use_count >= SCRAPING_BROWSER_MAX_USES
+
+      @browser_manager.restart
+      @browser_use_count = 0
     end
 
     def save_song(song_attrs)

--- a/app/services/scrapers/dam_scraper.rb
+++ b/app/services/scrapers/dam_scraper.rb
@@ -5,16 +5,16 @@ module Scrapers
   class DamScraper < BaseScraper
     # DAM楽曲ページをスクレイピング
     def scrape_song_page(dam_song)
-      # Ferrum::TimeoutErrorが発生したら即座にブラウザをリセット
+      # リトライ対象エラー（DeadBrowserError等含む）発生時は即座にブラウザをリセット
       with_retry(
         max_retries: 3,
-        errors: [Ferrum::TimeoutError],
         on_retry: lambda do |error, retry_count|
           Admin::OperationLogger.log(level: :warn, event: :external_fetch, action: :retry, resource: :browser, error: error.class, retry_count:, max_retries: 3)
           reset_browser_manager(timeout: 10, process_timeout: 10)
         end
       ) do
         browser_manager.with_browser do |_browser|
+          browser_manager.clear_network_traffic
           browser_manager.visit(dam_song.url)
 
           song_info = extract_song_info
@@ -32,10 +32,9 @@ module Scrapers
       # 並列処理での競合を避けるため、各ワーカーで新しいブラウザインスタンスを作成
       local_browser_manager = BrowserManager.new
 
-      # Ferrum::TimeoutErrorが発生したら即座にブラウザをリセット
+      # リトライ対象エラー（DeadBrowserError等含む）発生時は即座にブラウザをリセット
       with_retry(
         max_retries: 3,
-        errors: [Ferrum::TimeoutError],
         on_retry: lambda do |error, retry_count|
           Admin::OperationLogger.log(level: :warn, event: :external_fetch, action: :retry, resource: :browser, error: error.class, retry_count:, max_retries: 3)
           local_browser_manager = BrowserManager.new

--- a/app/services/scrapers/dam_scraper.rb
+++ b/app/services/scrapers/dam_scraper.rb
@@ -22,6 +22,7 @@ module Scrapers
           create_or_update_song(dam_song, song_info) if song_info[:title].present? && song_info[:title_reading].present? && song_info[:song_number].present?
         end
       end
+      track_browser_use
     rescue StandardError => e
       Admin::OperationLogger.log(level: :error, event: :external_fetch, action: :error, resource: :song, id: dam_song.id, url: dam_song.url, karaoke_type:, error: e.message)
       raise

--- a/app/services/scrapers/joysound_scraper.rb
+++ b/app/services/scrapers/joysound_scraper.rb
@@ -46,6 +46,7 @@ module Scrapers
           scrape_artist_and_songs if should_scrape?(composer, url)
         end
       end
+      track_browser_use
     rescue StandardError => e
       Admin::OperationLogger.log(level: :error, event: :external_fetch, action: :error, resource: :song, url:, karaoke_type:, error: e.message)
       raise
@@ -68,6 +69,7 @@ module Scrapers
           end
         end
       end
+      track_browser_use
     rescue ActiveRecord::RecordInvalid => e
       error_details = if e.record.respond_to?(:errors)
                         e.record.errors.full_messages.join(", ")

--- a/app/services/scraping_rate_limiter.rb
+++ b/app/services/scraping_rate_limiter.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "uri"
+
+# 相手サイト（DAM/JOYSOUND）への負荷をスレッド数に依存させないための、ホスト別グローバルレートリミッタ。
+#
+# BrowserManager#visit のような、スクレイピングの実リクエスト発火点（choke point）から呼び出すことで、
+# 並列スレッド数を増やしても相手サイトへの実効QPSをホスト単位で一定に保つ。BrowserManager 自体は
+# スレッド毎に別インスタンスになるため、共有すべき状態（ホスト別の最終リクエスト時刻など）は
+# このクラスのクラスレベル状態として持つ。
+class ScrapingRateLimiter
+  class << self
+    attr_writer :clock, :sleeper
+
+    # url のホストに対する最小リクエスト間隔を空けてから block を実行し、その戻り値を返す。
+    #
+    # 間隔保証（経過時間の確認・sleep・最終リクエスト時刻の更新）はホスト別Mutexの中で行うため、
+    # 同一ホストへの呼び出しは直列化され、間隔が正しく保たれる。一方 block（実際のリクエスト）自体は
+    # Mutexの外で実行する。次回呼び出しは更新済みの最終リクエスト時刻を見るため、この実装でも
+    # 間隔保証は成立し、かつリクエスト処理中（wait_for_idle等で長時間かかりうる）に他ホストや
+    # 後続呼び出しを不必要にブロックしない。シンプルさと正しさを両立できるこちらを採用した。
+    def throttle(url)
+      host = extract_host(url)
+
+      mutex_for(host).synchronize do
+        wait = min_interval_for(host) - elapsed_since_last_start(host)
+        pause(wait) if wait.positive?
+        last_started_at[host] = now
+      end
+
+      yield
+    end
+
+    # テスト用: ホスト別Mutex・最終リクエスト時刻・注入したclock/sleeperをすべてクリアする
+    def reset!
+      @host_mutexes = Concurrent::Map.new
+      @last_started_at = Concurrent::Map.new
+      @clock = nil
+      @sleeper = nil
+    end
+
+    private
+
+    def extract_host(url)
+      URI.parse(url).host || "default"
+    rescue StandardError
+      "default"
+    end
+
+    def min_interval_for(host)
+      case host
+      when /dam/i
+        ENV.fetch("SCRAPING_MIN_INTERVAL_DAM", "1.0").to_f
+      when /joysound/i
+        ENV.fetch("SCRAPING_MIN_INTERVAL_JOYSOUND", "1.0").to_f
+      else
+        ENV.fetch("SCRAPING_MIN_INTERVAL_DEFAULT", "1.0").to_f
+      end
+    end
+
+    def elapsed_since_last_start(host)
+      last = last_started_at[host]
+      return Float::INFINITY unless last
+
+      now - last
+    end
+
+    # ホスト毎のMutexを取得する。Concurrent::Mapのcompute_if_absentはアトミックなので、
+    # 複数スレッドが同時に初回アクセスしても生成されるMutexはホストごとに1つだけになる。
+    def mutex_for(host)
+      host_mutexes.compute_if_absent(host) { Mutex.new }
+    end
+
+    def host_mutexes
+      @host_mutexes ||= Concurrent::Map.new
+    end
+
+    def last_started_at
+      @last_started_at ||= Concurrent::Map.new
+    end
+
+    def now
+      clock.call
+    end
+
+    def pause(seconds)
+      sleeper.call(seconds)
+    end
+
+    def clock
+      @clock ||= -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+    end
+
+    def sleeper
+      @sleeper ||= ->(seconds) { Kernel.sleep(seconds) }
+    end
+  end
+end

--- a/app/services/song_external_sync.rb
+++ b/app/services/song_external_sync.rb
@@ -8,16 +8,23 @@ class SongExternalSync
     end
 
     def fetch_joysound_songs(progress: nil)
-      scraper = Scrapers::JoysoundScraper.new
       joysound_songs = JoysoundSong.all
       existing_joysound_keys = Song.where(karaoke_type: "JOYSOUND").pluck(:title, :url).to_set
 
-      Song.process_with_progress(joysound_songs, label: "JOYSOUND楽曲", progress:, progress_options: { status: "JOYSOUND楽曲取得中", label: "JOYSOUND楽曲詳細を取得しています" }) do |record|
+      Song.process_with_progress(
+        joysound_songs,
+        label: "JOYSOUND楽曲",
+        progress:,
+        progress_options: { status: "JOYSOUND楽曲取得中", label: "JOYSOUND楽曲詳細を取得しています" },
+        worker_factory: -> { Scrapers::JoysoundScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
+        worker_teardown: ->(w) { w.shutdown }
+      ) do |record, scraper|
         title = record.display_title.split("／").first
         scraper.scrape_song_page(record.url) unless existing_joysound_keys.include?([title, record.url])
       end
 
       existing_joysound_urls = Song.where(karaoke_type: "JOYSOUND").pluck(:url).to_set
+      allowlist_scraper = Scrapers::JoysoundScraper.new
 
       Constants::Karaoke::JOYSOUND_ALLOWLIST.each.with_index(1) do |url, index|
         next if existing_joysound_urls.include?(url)
@@ -31,15 +38,19 @@ class SongExternalSync
           current: index,
           total: Constants::Karaoke::JOYSOUND_ALLOWLIST.count
         )
-        scraper.scrape_song_page(url)
+        allowlist_scraper.scrape_song_page(url)
       end
     end
 
     def fetch_joysound_music_post_song
-      scraper = Scrapers::JoysoundScraper.new
       prioritized_posts = JoysoundMusicPostPrioritizer.call
 
-      Song.process_with_progress(prioritized_posts, label: "ミュージックポスト") do |record|
+      Song.process_with_progress(
+        prioritized_posts,
+        label: "ミュージックポスト",
+        worker_factory: -> { Scrapers::JoysoundScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
+        worker_teardown: ->(w) { w.shutdown }
+      ) do |record, scraper|
         scraper.scrape_music_post_page(record)
       end
     end
@@ -70,11 +81,17 @@ class SongExternalSync
     end
 
     def fetch_dam_songs(progress: nil)
-      scraper = Scrapers::DamScraper.new
       dam_songs = DamSong.order(created_at: :desc)
       existing_dam_urls = Song.where(karaoke_type: "DAM").pluck(:url).to_set
 
-      Song.process_with_progress(dam_songs, label: "DAM楽曲", progress:, progress_options: { status: "DAM楽曲取得中", label: "DAM楽曲詳細を取得しています" }) do |record|
+      Song.process_with_progress(
+        dam_songs,
+        label: "DAM楽曲",
+        progress:,
+        progress_options: { status: "DAM楽曲取得中", label: "DAM楽曲詳細を取得しています" },
+        worker_factory: -> { Scrapers::DamScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
+        worker_teardown: ->(w) { w.shutdown }
+      ) do |record, scraper|
         next if existing_dam_urls.include?(record.url)
 
         scraper.scrape_song_page(record)
@@ -82,10 +99,16 @@ class SongExternalSync
     end
 
     def update_dam_delivery_models(progress: nil)
-      scraper = Scrapers::DamScraper.new
       dam_songs = Song.dam.includes(:karaoke_delivery_models)
 
-      Song.process_with_progress(dam_songs, label: "DAM配信機種更新", progress:, progress_options: { status: "DAM配信機種更新中", label: "DAM配信機種を更新しています" }) do |song|
+      Song.process_with_progress(
+        dam_songs,
+        label: "DAM配信機種更新",
+        progress:,
+        progress_options: { status: "DAM配信機種更新中", label: "DAM配信機種を更新しています" },
+        worker_factory: -> { Scrapers::DamScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
+        worker_teardown: ->(w) { w.shutdown }
+      ) do |song, scraper|
         scraper.update_delivery_models(song)
       end
     end

--- a/app/services/song_external_sync.rb
+++ b/app/services/song_external_sync.rb
@@ -17,7 +17,8 @@ class SongExternalSync
         progress:,
         progress_options: { status: "JOYSOUND楽曲取得中", label: "JOYSOUND楽曲詳細を取得しています" },
         worker_factory: -> { Scrapers::JoysoundScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
-        worker_teardown: ->(w) { w.shutdown }
+        worker_teardown: ->(w) { w.shutdown },
+        continue_on_error: true
       ) do |record, scraper|
         title = record.display_title.split("／").first
         scraper.scrape_song_page(record.url) unless existing_joysound_keys.include?([title, record.url])
@@ -49,7 +50,8 @@ class SongExternalSync
         prioritized_posts,
         label: "ミュージックポスト",
         worker_factory: -> { Scrapers::JoysoundScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
-        worker_teardown: ->(w) { w.shutdown }
+        worker_teardown: ->(w) { w.shutdown },
+        continue_on_error: true
       ) do |record, scraper|
         scraper.scrape_music_post_page(record)
       end
@@ -90,7 +92,8 @@ class SongExternalSync
         progress:,
         progress_options: { status: "DAM楽曲取得中", label: "DAM楽曲詳細を取得しています" },
         worker_factory: -> { Scrapers::DamScraper.new(browser_manager: BrowserManager.new(persistent: true)) },
-        worker_teardown: ->(w) { w.shutdown }
+        worker_teardown: ->(w) { w.shutdown },
+        continue_on_error: true
       ) do |record, scraper|
         next if existing_dam_urls.include?(record.url)
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,4 +37,11 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # ParallelProcessor の既定スレッド数(3)を明示的に上書きしない限り、テストでは逐次実行(1)にする。
+  # test/models/concerns/parallel_processor_test.rb 等の「既定」を前提にしたテストが、
+  # 意図せず並列パスに乗って非決定的にならないようにするため。
+  # 並列パスを検証するテストは各テスト内で ENV['SCRAPING_THREAD_COUNT'] を明示的に上書きしており、
+  # この既定値には依存しない。
+  ENV['SCRAPING_THREAD_COUNT'] ||= '1'
 end

--- a/test/models/concerns/parallel_processor_test.rb
+++ b/test/models/concerns/parallel_processor_test.rb
@@ -18,6 +18,7 @@ class ParallelProcessorTest < ActiveSupport::TestCase
 
   teardown do
     ENV.delete('SCRAPING_THREAD_COUNT')
+    ENV.delete('SCRAPING_CONSECUTIVE_FAILURE_LIMIT')
   end
 
   test '既定（スレッド数1）では各要素を順序通りに1回ずつ処理し、進捗の最終currentが要素数と一致する' do
@@ -186,5 +187,91 @@ class ParallelProcessorTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, teardown_calls.size
+  end
+
+  test 'continue_on_error: false（既定）ではブロックが例外を投げると従来通り伝播する' do
+    error = assert_raises(RuntimeError) do
+      DummyProcessor.process_with_progress([1, 2, 3], progress: ->(**_attrs) {}) do |record|
+        raise 'boom' if record == 2
+      end
+    end
+
+    assert_equal 'boom', error.message
+  end
+
+  test 'continue_on_error: trueでは一部レコードが例外を投げても全レコードが処理試行され、例外は伝播せず失敗が集約される（逐次）' do
+    records = [1, 2, 3, 4, 5]
+    processed = []
+
+    result = DummyProcessor.process_with_progress(records, progress: ->(**_attrs) {}, continue_on_error: true) do |record|
+      raise "boom #{record}" if [2, 4].include?(record)
+
+      processed << record
+    end
+
+    assert_equal [1, 3, 5], processed
+    assert_equal 2, result[:failed_count]
+    assert_equal 2, result[:failures].size
+    assert_not result[:stopped]
+  end
+
+  test 'continue_on_error: trueでは一部レコードが例外を投げても全レコードが処理試行され、例外は伝播せず失敗が集約される（並列）' do
+    ENV['SCRAPING_THREAD_COUNT'] = '3'
+    records = (1..20).to_a
+    mutex = Mutex.new
+    processed = []
+
+    result = DummyProcessor.process_with_progress(records, progress: ->(**_attrs) {}, continue_on_error: true) do |record|
+      raise "boom #{record}" if (record % 5).zero?
+
+      mutex.synchronize { processed << record }
+    end
+
+    assert_equal 16, processed.size
+    assert_equal 4, result[:failed_count]
+    assert_not result[:stopped]
+  end
+
+  test '連続失敗が閾値に達すると早期終了し、以降のレコードは処理されない（逐次）' do
+    ENV['SCRAPING_CONSECUTIVE_FAILURE_LIMIT'] = '3'
+    records = (1..10).to_a
+    processed = []
+
+    result = DummyProcessor.process_with_progress(records, progress: ->(**_attrs) {}, continue_on_error: true) do |record|
+      processed << record
+      raise "boom #{record}"
+    end
+
+    assert_equal [1, 2, 3], processed
+    assert_equal 3, result[:failed_count]
+    assert result[:stopped]
+  end
+
+  test '並列実行でも連続失敗が閾値に達するとstoppedが立つ（非決定的なため停止したことのみ確認する）' do
+    ENV['SCRAPING_THREAD_COUNT'] = '2'
+    ENV['SCRAPING_CONSECUTIVE_FAILURE_LIMIT'] = '2'
+    records = (1..20).to_a
+
+    result = DummyProcessor.process_with_progress(records, progress: ->(**_attrs) {}, continue_on_error: true) do |_record|
+      raise 'boom'
+    end
+
+    assert result[:stopped]
+    assert_operator result[:failed_count], :<=, records.size
+  end
+
+  test '成功が挟まると連続失敗カウンタがリセットされ、閾値に達しても早期終了しない' do
+    ENV['SCRAPING_CONSECUTIVE_FAILURE_LIMIT'] = '2'
+    records = (1..6).to_a
+    processed = []
+
+    result = DummyProcessor.process_with_progress(records, progress: ->(**_attrs) {}, continue_on_error: true) do |record|
+      processed << record
+      raise "boom #{record}" if record.odd?
+    end
+
+    assert_equal records, processed
+    assert_equal 3, result[:failed_count]
+    assert_not result[:stopped]
   end
 end

--- a/test/models/concerns/parallel_processor_test.rb
+++ b/test/models/concerns/parallel_processor_test.rb
@@ -5,6 +5,17 @@ class ParallelProcessorTest < ActiveSupport::TestCase
     include ParallelProcessor
   end
 
+  # factoryが呼ばれる度に生成数をカウントし、生成したワーカー自身に処理済みレコードとteardown状態を記録させるフェイクワーカー。
+  class FakeWorker
+    attr_reader :processed_records
+    attr_accessor :torn_down
+
+    def initialize
+      @processed_records = []
+      @torn_down = false
+    end
+  end
+
   teardown do
     ENV.delete('SCRAPING_THREAD_COUNT')
   end
@@ -82,5 +93,98 @@ class ParallelProcessorTest < ActiveSupport::TestCase
 
     assert_equal artists.map(&:id).sort, processed.map(&:id).sort
     assert_equal artists.size, processed.size
+  end
+
+  test 'ActiveRecord::Relationはeach_sliceではなくfind_in_batches経由でバッチ処理される（メモリ境界化）' do
+    ENV['SCRAPING_THREAD_COUNT'] = '3'
+    artists = Array.new(5) { create_display_artist }
+    relation = DisplayArtist.where(id: artists.map(&:id))
+    processed = []
+    mutex = Mutex.new
+
+    # Array向けのeach_sliceパス（全件を配列化する経路）が使われていないことを確認する。
+    # find_in_batchesはSQLのLIMIT/OFFSET相当でバッチを取得するため、全件を一括メモリ展開しない。
+    relation.define_singleton_method(:each_slice) do |*_args|
+      raise 'each_sliceが呼ばれてはならない（ActiveRecord::Relationはfind_in_batches経由であるべき）'
+    end
+
+    DummyProcessor.process_with_progress(relation, progress: ->(**_attrs) {}) do |record|
+      mutex.synchronize { processed << record }
+    end
+
+    assert_equal artists.map(&:id).sort, processed.map(&:id).sort
+  end
+
+  test 'worker_factory指定時、逐次実行ではfactoryは1回だけ呼ばれ、全レコードが同一workerで処理され、shutdown後にteardownされる' do
+    records = [1, 2, 3, 4, 5]
+    factory_call_count = 0
+    torn_down_workers = []
+
+    DummyProcessor.process_with_progress(
+      records,
+      progress: ->(**_attrs) {},
+      worker_factory: lambda {
+        factory_call_count += 1
+        FakeWorker.new
+      },
+      worker_teardown: lambda { |worker|
+        worker.torn_down = true
+        torn_down_workers << worker
+      }
+    ) do |record, worker|
+      worker.processed_records << record
+    end
+
+    assert_equal 1, factory_call_count
+    assert_equal 1, torn_down_workers.size
+    assert_equal records, torn_down_workers.first.processed_records
+    assert torn_down_workers.first.torn_down
+  end
+
+  test 'worker_factory指定時、並列実行ではfactory呼び出し数がthread_count以下で、各レコードがちょうど1回処理され、生成された全workerがteardownされる' do
+    ENV['SCRAPING_THREAD_COUNT'] = '3'
+    records = (1..20).to_a
+    mutex = Mutex.new
+    created_workers = []
+    processed = []
+
+    DummyProcessor.process_with_progress(
+      records,
+      progress: ->(**_attrs) {},
+      worker_factory: lambda {
+        mutex.synchronize do
+          worker = FakeWorker.new
+          created_workers << worker
+          worker
+        end
+      },
+      worker_teardown: ->(worker) { worker.torn_down = true }
+    ) do |record, worker|
+      mutex.synchronize { processed << record }
+      worker.processed_records << record
+    end
+
+    assert_equal records.sort, processed.sort
+    assert_operator created_workers.size, :<=, 3
+    assert created_workers.all?(&:torn_down)
+  end
+
+  test 'worker_teardownが例外を投げても他のworkerのteardownは実行され、例外は伝播しない' do
+    records = [1, 2]
+    teardown_calls = []
+
+    DummyProcessor.process_with_progress(
+      records,
+      progress: ->(**_attrs) {},
+      worker_factory: -> { FakeWorker.new },
+      worker_teardown: lambda { |worker|
+        teardown_calls << worker
+        raise 'teardown boom'
+      }
+    ) do |record, worker|
+      worker.processed_records << record
+    end
+
+    assert_equal 1, teardown_calls.size
   end
 end

--- a/test/models/concerns/retryable_test.rb
+++ b/test/models/concerns/retryable_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+class RetryableTest < ActiveSupport::TestCase
+  class DummyRetryable
+    include Retryable
+  end
+
+  # sleepとrandをスタブし、sleepに渡された秒数を記録する配列を返す
+  def stub_sleep_and_rand(target, rand_value: 0)
+    delays = []
+    target.define_singleton_method(:sleep) { |seconds| delays << seconds }
+    target.define_singleton_method(:rand) { rand_value }
+    delays
+  end
+
+  test '指数的に増加するdelayでsleepし、max_delayに達したらクランプされる' do
+    delays = stub_sleep_and_rand(DummyRetryable, rand_value: 0)
+    attempt = 0
+
+    DummyRetryable.with_retry(max_retries: 5, base_delay: 0.5, max_delay: 2.0) do
+      attempt += 1
+      raise Ferrum::TimeoutError if attempt <= 5
+    end
+
+    assert_equal [0.5, 1.0, 2.0, 2.0, 2.0], delays
+  end
+
+  test 'jitterはdelay〜delay*(1+jitter)の範囲に収まる' do
+    delays = stub_sleep_and_rand(DummyRetryable, rand_value: 0.5)
+    attempt = 0
+
+    DummyRetryable.with_retry(max_retries: 1, base_delay: 1.0, max_delay: 10.0, jitter: 0.5) do
+      attempt += 1
+      raise Ferrum::TimeoutError if attempt <= 1
+    end
+
+    # delay = 1.0, jitter加算 = rand(=0.5) * jitter(0.5) * delay(1.0) = 0.25
+    assert_equal [1.25], delays
+    assert delays.first.between?(1.0, 1.0 * 1.5)
+  end
+
+  test 'Ferrum::DeadBrowserErrorはリトライ対象で、成功するまでretryする' do
+    stub_sleep_and_rand(DummyRetryable)
+    attempt = 0
+
+    result = DummyRetryable.with_retry(max_retries: 3) do
+      attempt += 1
+      raise Ferrum::DeadBrowserError if attempt < 3
+
+      'success'
+    end
+
+    assert_equal 'success', result
+    assert_equal 3, attempt
+  end
+
+  test '最大リトライ回数を超えると元の例外がraiseされる' do
+    stub_sleep_and_rand(DummyRetryable)
+
+    error = assert_raises(Ferrum::TimeoutError) do
+      DummyRetryable.with_retry(max_retries: 2) { raise Ferrum::TimeoutError }
+    end
+    assert_kind_of Ferrum::TimeoutError, error
+  end
+
+  test 'on_retryはリトライ回数分、(error, retry_count)を引数に呼ばれる' do
+    stub_sleep_and_rand(DummyRetryable)
+    calls = []
+    attempt = 0
+
+    DummyRetryable.with_retry(max_retries: 3, on_retry: ->(e, count) { calls << [e.class, count] }) do
+      attempt += 1
+      raise Ferrum::TimeoutError if attempt <= 2
+
+      'ok'
+    end
+
+    assert_equal [[Ferrum::TimeoutError, 1], [Ferrum::TimeoutError, 2]], calls
+  end
+
+  test '非リトライ対象の例外はそのままraiseされる' do
+    stub_sleep_and_rand(DummyRetryable)
+
+    assert_raises(ArgumentError) do
+      DummyRetryable.with_retry { raise ArgumentError, 'invalid' }
+    end
+  end
+
+  test 'インスタンス版はclass_methods版のバックオフ処理へ委譲する' do
+    delays = stub_sleep_and_rand(DummyRetryable, rand_value: 0)
+    attempt = 0
+
+    result = DummyRetryable.new.with_retry(max_retries: 2, base_delay: 0.5, max_delay: 8.0) do
+      attempt += 1
+      raise Ferrum::TimeoutError if attempt <= 1
+
+      'done'
+    end
+
+    assert_equal 'done', result
+    assert_equal [0.5], delays
+  end
+end

--- a/test/services/browser_manager_test.rb
+++ b/test/services/browser_manager_test.rb
@@ -177,6 +177,40 @@ class BrowserManagerTest < ActiveSupport::TestCase
     end
   end
 
+  test 'visit routes the actual request through ScrapingRateLimiter.throttle' do
+    created = []
+    throttle_calls = []
+
+    with_stubbed_browser_new(created) do
+      with_stubbed_rate_limiter_throttle(throttle_calls, yields: true) do
+        manager = BrowserManager.new(persistent: true)
+        manager.with_browser { manager.visit('https://example.com', wait_duration: 2.0) }
+
+        browser = created.first
+        assert_equal ['https://example.com'], throttle_calls
+        assert_equal ['https://example.com'], browser.goto_calls
+        assert_equal [{ duration: 2.0, timeout: 10 }], browser.network.wait_for_idle_calls
+      end
+    end
+  end
+
+  test 'visit does not goto/wait_for_idle unless ScrapingRateLimiter.throttle yields' do
+    created = []
+    throttle_calls = []
+
+    with_stubbed_browser_new(created) do
+      with_stubbed_rate_limiter_throttle(throttle_calls, yields: false) do
+        manager = BrowserManager.new(persistent: true)
+        manager.with_browser { manager.visit('https://example.com') }
+
+        browser = created.first
+        assert_equal ['https://example.com'], throttle_calls
+        assert_empty browser.goto_calls
+        assert_empty browser.network.wait_for_idle_calls
+      end
+    end
+  end
+
   private
 
   def with_stubbed_browser_new(created_browsers)
@@ -188,6 +222,22 @@ class BrowserManagerTest < ActiveSupport::TestCase
   ensure
     Ferrum::Browser.define_singleton_method(:new) do |*args, **kwargs, &block|
       original_new.call(*args, **kwargs, &block)
+    end
+  end
+
+  # ScrapingRateLimiter.throttle をスタブし、visit が実際にそのブロック経由で
+  # goto/wait_for_idle を呼び出していることを検証できるようにする。
+  # yields: false の場合はブロックを呼ばず、goto等がthrottleの外側で呼ばれていないことを確認できる。
+  def with_stubbed_rate_limiter_throttle(recorded_urls, yields:)
+    original_throttle = ScrapingRateLimiter.method(:throttle)
+    ScrapingRateLimiter.define_singleton_method(:throttle) do |url, &block|
+      recorded_urls << url
+      block.call if yields
+    end
+    yield
+  ensure
+    ScrapingRateLimiter.define_singleton_method(:throttle) do |*args, **kwargs, &block|
+      original_throttle.call(*args, **kwargs, &block)
     end
   end
 end

--- a/test/services/browser_manager_test.rb
+++ b/test/services/browser_manager_test.rb
@@ -1,0 +1,193 @@
+require 'test_helper'
+
+class BrowserManagerTest < ActiveSupport::TestCase
+  class FakeNetwork
+    attr_reader :clear_calls, :wait_for_idle_calls
+
+    def initialize
+      @clear_calls = []
+      @wait_for_idle_calls = []
+    end
+
+    def clear(type)
+      @clear_calls << type
+    end
+
+    def wait_for_idle(duration:, timeout: nil)
+      @wait_for_idle_calls << { duration:, timeout: }
+    end
+  end
+
+  class FakeBrowser
+    attr_reader :quit_calls, :reset_calls, :goto_calls, :network
+
+    def initialize
+      @quit_calls = 0
+      @reset_calls = 0
+      @goto_calls = []
+      @network = FakeNetwork.new
+    end
+
+    def quit
+      @quit_calls += 1
+    end
+
+    def reset
+      @reset_calls += 1
+    end
+
+    def goto(url)
+      @goto_calls << url
+    end
+  end
+
+  test 'with_browser starts and quits a new browser on every call by default' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new
+
+      manager.with_browser { |browser| browser.goto('https://example.com/1') }
+      manager.with_browser { |browser| browser.goto('https://example.com/2') }
+
+      assert_equal 2, created.size
+      assert(created.all? { |browser| browser.quit_calls == 1 })
+      assert_not manager.started?
+    end
+  end
+
+  test 'with_browser reuses the same browser and never quits in persistent mode' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+
+      manager.with_browser { |browser| browser.goto('https://example.com/1') }
+      manager.with_browser { |browser| browser.goto('https://example.com/2') }
+
+      assert_equal 1, created.size
+      assert_equal 0, created.first.quit_calls
+      assert manager.started?
+      assert manager.persistent?
+    end
+  end
+
+  test 'close quits a persistent browser exactly once' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+      manager.with_browser { |browser| browser.goto('https://example.com') }
+
+      manager.close
+
+      assert_equal 1, created.first.quit_calls
+      assert_not manager.started?
+    end
+  end
+
+  test 'restart quits the current browser then starts a fresh one' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+      manager.with_browser { |browser| browser.goto('https://example.com') }
+      first_browser = created.first
+
+      manager.restart
+
+      assert_equal 1, first_browser.quit_calls
+      assert_equal 2, created.size
+      assert manager.started?
+    end
+  end
+
+  test 'reset_session clears cookies/session state and network traffic when started' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+      manager.with_browser { |browser| browser.goto('https://example.com') }
+
+      manager.reset_session
+
+      assert_equal 1, created.first.reset_calls
+      assert_equal [:traffic], created.first.network.clear_calls
+    end
+  end
+
+  test 'reset_session does nothing when the browser is not started' do
+    manager = BrowserManager.new
+
+    manager.reset_session
+
+    assert_not manager.started?
+  end
+
+  test 'started? and persistent? reflect manager state' do
+    manager = BrowserManager.new
+    assert_not manager.started?
+    assert_not manager.persistent?
+
+    persistent_manager = BrowserManager.new(persistent: true)
+    assert persistent_manager.persistent?
+  end
+
+  test 'exceptions inside with_browser propagate and keep the persistent browser alive' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+
+      error = assert_raises(RuntimeError) do
+        manager.with_browser { |_browser| raise 'boom' }
+      end
+
+      assert_equal 'boom', error.message
+      assert manager.started?
+      assert_equal 0, created.first.quit_calls
+    end
+  end
+
+  test 'exceptions inside with_browser propagate and still quit a non-persistent browser' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new
+
+      assert_raises(RuntimeError) do
+        manager.with_browser { |_browser| raise 'boom' }
+      end
+
+      assert_not manager.started?
+      assert_equal 1, created.first.quit_calls
+    end
+  end
+
+  test 'visit waits for idle using the configured timeout' do
+    created = []
+
+    with_stubbed_browser_new(created) do
+      manager = BrowserManager.new(persistent: true)
+      manager.with_browser { manager.visit('https://example.com', wait_duration: 2.0) }
+
+      browser = created.first
+      assert_equal ['https://example.com'], browser.goto_calls
+      assert_equal [{ duration: 2.0, timeout: 10 }], browser.network.wait_for_idle_calls
+    end
+  end
+
+  private
+
+  def with_stubbed_browser_new(created_browsers)
+    original_new = Ferrum::Browser.method(:new)
+    Ferrum::Browser.define_singleton_method(:new) do |*_args, **_kwargs|
+      FakeBrowser.new.tap { |browser| created_browsers << browser }
+    end
+    yield
+  ensure
+    Ferrum::Browser.define_singleton_method(:new) do |*args, **kwargs, &block|
+      original_new.call(*args, **kwargs, &block)
+    end
+  end
+end

--- a/test/services/joysound_music_post_manager_test.rb
+++ b/test/services/joysound_music_post_manager_test.rb
@@ -9,6 +9,32 @@ class JoysoundMusicPostManagerTest < ActiveSupport::TestCase
     end
   end
 
+  test 'fetch_songs_with_progress wires a persistent JoysoundScraper worker_factory and worker_teardown into process_with_progress' do
+    captured = nil
+    original = JoysoundMusicPostManager.method(:process_with_progress)
+
+    # process_with_progress自体を丸ごとスタブする（呼び出し引数のみ捕捉し、ブロックは実行しない）ため、
+    # スクレイピング（実サイトへのアクセス）は一切発生しない。
+    JoysoundMusicPostManager.define_singleton_method(:process_with_progress) do |*_args, **kwargs, &_block|
+      captured = kwargs
+      nil
+    end
+
+    begin
+      JoysoundMusicPostManager.new.fetch_songs_with_progress
+    ensure
+      JoysoundMusicPostManager.define_singleton_method(:process_with_progress) do |*args, **kwargs, &block|
+        original.call(*args, **kwargs, &block)
+      end
+    end
+
+    assert_respond_to captured[:worker_factory], :call
+    assert_respond_to captured[:worker_teardown], :call
+
+    worker = captured[:worker_factory].call
+    assert_instance_of Scrapers::JoysoundScraper, worker
+  end
+
   test 'refresh_songs_efficiently deletes 404 songs and skips retryable network errors' do
     deleted_song = create_music_post_song(title: 'Deleted Music Post Song', url: 'https://example.com/music-post/deleted')
     skipped_song = create_music_post_song(title: 'Skipped Music Post Song', url: 'https://example.com/music-post/skipped')

--- a/test/services/scrapers/base_scraper_test.rb
+++ b/test/services/scrapers/base_scraper_test.rb
@@ -98,6 +98,24 @@ module Scrapers
       assert_equal [{ timeout: 10, process_timeout: 10 }, { persistent: false }], captured_args
     end
 
+    test 'track_browser_use is a no-op when the browser manager is not persistent' do
+      fake_manager = FakeBrowserManager.new(persistent: false)
+      scraper = TestScraper.new(browser_manager: fake_manager)
+
+      3.times { scraper.call_track_browser_use }
+
+      assert_equal 0, fake_manager.reset_session_calls
+      assert_equal 0, fake_manager.restart_calls
+    end
+
+    test 'track_browser_use is a no-op when the browser manager is nil' do
+      scraper = TestScraper.new(browser_manager: nil)
+
+      scraper.call_track_browser_use
+
+      assert_nil scraper.current_browser_manager
+    end
+
     test 'track_browser_use resets the session on every call without restarting under the limit' do
       original_max_uses = BaseScraper::SCRAPING_BROWSER_MAX_USES
       BaseScraper.send(:remove_const, :SCRAPING_BROWSER_MAX_USES)

--- a/test/services/scrapers/base_scraper_test.rb
+++ b/test/services/scrapers/base_scraper_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Scrapers
+  class BaseScraperTest < ActiveSupport::TestCase
+    class FakeBrowserManager
+      attr_reader :close_calls, :restart_calls, :reset_session_calls
+
+      def initialize(persistent: false)
+        @close_calls = 0
+        @restart_calls = 0
+        @reset_session_calls = 0
+        @persistent = persistent
+      end
+
+      def close
+        @close_calls += 1
+      end
+
+      def restart
+        @restart_calls += 1
+      end
+
+      def reset_session
+        @reset_session_calls += 1
+      end
+
+      def started?
+        true
+      end
+
+      def persistent?
+        @persistent
+      end
+    end
+
+    # BaseScraperはabstractなため、検証用の最小サブクラスを定義する
+    class TestScraper < BaseScraper
+      def karaoke_type
+        "TEST"
+      end
+
+      def call_reset_browser_manager(**)
+        reset_browser_manager(**)
+      end
+
+      def call_track_browser_use
+        track_browser_use
+      end
+
+      def current_browser_manager
+        browser_manager
+      end
+    end
+
+    test 'shutdown closes the browser manager' do
+      fake_manager = FakeBrowserManager.new
+      scraper = TestScraper.new(browser_manager: fake_manager)
+
+      scraper.shutdown
+
+      assert_equal 1, fake_manager.close_calls
+    end
+
+    test 'shutdown does nothing when the browser manager is nil' do
+      scraper = TestScraper.new(browser_manager: nil)
+
+      scraper.shutdown
+
+      assert_nil scraper.current_browser_manager
+    end
+
+    test 'reset_browser_manager preserves the persistent flag while applying new options' do
+      fake_manager = FakeBrowserManager.new(persistent: true)
+      scraper = TestScraper.new(browser_manager: fake_manager)
+      replacement_manager = FakeBrowserManager.new(persistent: true)
+      captured_args = nil
+
+      with_stubbed_browser_manager_new(replacement_manager, captured: ->(args) { captured_args = args }) do
+        scraper.call_reset_browser_manager(timeout: 20, process_timeout: 15)
+      end
+
+      assert_equal [{ timeout: 20, process_timeout: 15 }, { persistent: true }], captured_args
+      assert_same replacement_manager, scraper.current_browser_manager
+    end
+
+    test 'reset_browser_manager keeps a non-persistent manager non-persistent' do
+      fake_manager = FakeBrowserManager.new(persistent: false)
+      scraper = TestScraper.new(browser_manager: fake_manager)
+      replacement_manager = FakeBrowserManager.new(persistent: false)
+      captured_args = nil
+
+      with_stubbed_browser_manager_new(replacement_manager, captured: ->(args) { captured_args = args }) do
+        scraper.call_reset_browser_manager
+      end
+
+      assert_equal [{ timeout: 10, process_timeout: 10 }, { persistent: false }], captured_args
+    end
+
+    test 'track_browser_use resets the session on every call without restarting under the limit' do
+      original_max_uses = BaseScraper::SCRAPING_BROWSER_MAX_USES
+      BaseScraper.send(:remove_const, :SCRAPING_BROWSER_MAX_USES)
+      BaseScraper.const_set(:SCRAPING_BROWSER_MAX_USES, 3)
+
+      fake_manager = FakeBrowserManager.new(persistent: true)
+      scraper = TestScraper.new(browser_manager: fake_manager)
+
+      2.times { scraper.call_track_browser_use }
+
+      assert_equal 2, fake_manager.reset_session_calls
+      assert_equal 0, fake_manager.restart_calls
+    ensure
+      BaseScraper.send(:remove_const, :SCRAPING_BROWSER_MAX_USES)
+      BaseScraper.const_set(:SCRAPING_BROWSER_MAX_USES, original_max_uses)
+    end
+
+    test 'track_browser_use restarts the browser and resets the counter once the limit is reached' do
+      original_max_uses = BaseScraper::SCRAPING_BROWSER_MAX_USES
+      BaseScraper.send(:remove_const, :SCRAPING_BROWSER_MAX_USES)
+      BaseScraper.const_set(:SCRAPING_BROWSER_MAX_USES, 3)
+
+      fake_manager = FakeBrowserManager.new(persistent: true)
+      scraper = TestScraper.new(browser_manager: fake_manager)
+
+      3.times { scraper.call_track_browser_use }
+
+      assert_equal 3, fake_manager.reset_session_calls
+      assert_equal 1, fake_manager.restart_calls
+
+      # カウンタがリセットされているため、次のtrack_browser_useではrestartが呼ばれない
+      scraper.call_track_browser_use
+      assert_equal 1, fake_manager.restart_calls
+    ensure
+      BaseScraper.send(:remove_const, :SCRAPING_BROWSER_MAX_USES)
+      BaseScraper.const_set(:SCRAPING_BROWSER_MAX_USES, original_max_uses)
+    end
+
+    private
+
+    def with_stubbed_browser_manager_new(replacement_manager, captured:)
+      original_new = BrowserManager.method(:new)
+      BrowserManager.define_singleton_method(:new) do |*args, **kwargs|
+        captured.call([*args, kwargs])
+        replacement_manager
+      end
+      yield
+    ensure
+      BrowserManager.define_singleton_method(:new) do |*args, **kwargs, &block|
+        original_new.call(*args, **kwargs, &block)
+      end
+    end
+  end
+end

--- a/test/services/scrapers/joysound_scraper_test.rb
+++ b/test/services/scrapers/joysound_scraper_test.rb
@@ -53,6 +53,10 @@ module Scrapers
       def visit(url)
         calls << [:visit, url]
       end
+
+      def persistent?
+        false
+      end
     end
 
     test 'extract_delivery_models keeps only JOYSOUND model chips' do

--- a/test/services/scraping_rate_limiter_test.rb
+++ b/test/services/scraping_rate_limiter_test.rb
@@ -1,0 +1,140 @@
+require 'test_helper'
+
+class ScrapingRateLimiterTest < ActiveSupport::TestCase
+  # 実時間を使わずに throttle のロジックを検証するためのフェイク単調時計。
+  # sleeper 経由でのみ時刻が進むので、テストのアサーションが決定的になる。
+  class FakeClock
+    def initialize
+      @now = 0.0
+      @mutex = Mutex.new
+    end
+
+    def now
+      @mutex.synchronize { @now }
+    end
+
+    def advance(seconds)
+      @mutex.synchronize { @now += seconds }
+    end
+  end
+
+  setup do
+    ScrapingRateLimiter.reset!
+
+    @fake_clock = FakeClock.new
+    @sleep_calls = []
+    @sleep_calls_mutex = Mutex.new
+
+    fake_clock = @fake_clock
+    sleep_calls = @sleep_calls
+    sleep_calls_mutex = @sleep_calls_mutex
+
+    ScrapingRateLimiter.clock = -> { fake_clock.now }
+    ScrapingRateLimiter.sleeper = lambda do |seconds|
+      sleep_calls_mutex.synchronize { sleep_calls << seconds }
+      fake_clock.advance(seconds)
+    end
+  end
+
+  teardown do
+    ScrapingRateLimiter.reset!
+  end
+
+  test 'the first call for a host does not sleep' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '1.0') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { nil }
+    end
+
+    assert_empty @sleep_calls
+  end
+
+  test 'consecutive calls to the same host sleep for the remaining interval' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '2.0') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { nil }
+      @fake_clock.advance(0.5)
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/b') { nil }
+    end
+
+    assert_equal [1.5], @sleep_calls
+  end
+
+  test 'a call after the interval has already elapsed does not sleep' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '1.0') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { nil }
+      @fake_clock.advance(2.0)
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/b') { nil }
+    end
+
+    assert_empty @sleep_calls
+  end
+
+  test 'different hosts are throttled independently' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '5.0', 'SCRAPING_MIN_INTERVAL_JOYSOUND' => '5.0') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { nil }
+      # 同一ホストへの2回目なので待たされる
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/b') { nil }
+      # 別ホストへの初回呼び出しなので、DAM側の待機時間を引き継がない
+      ScrapingRateLimiter.throttle('https://www.joysound.com/a') { nil }
+    end
+
+    assert_equal [5.0], @sleep_calls
+  end
+
+  test 'urls without a parsable host fall back to a shared default bucket without raising' do
+    with_env('SCRAPING_MIN_INTERVAL_DEFAULT' => '4.0') do
+      assert_nothing_raised do
+        ScrapingRateLimiter.throttle('') { nil }
+        ScrapingRateLimiter.throttle('not a valid url') { nil }
+      end
+    end
+
+    assert_equal [4.0], @sleep_calls
+  end
+
+  test 'the return value of the block is returned' do
+    result = with_env('SCRAPING_MIN_INTERVAL_DAM' => '1.0') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { 'block result' }
+    end
+
+    assert_equal 'block result', result
+  end
+
+  test 'SCRAPING_MIN_INTERVAL_DAM controls the interval for dam hosts' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '0.3') do
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/a') { nil }
+      ScrapingRateLimiter.throttle('https://www.clubdam.com/b') { nil }
+    end
+
+    assert_equal [0.3], @sleep_calls
+  end
+
+  test 'SCRAPING_MIN_INTERVAL_JOYSOUND controls the interval for joysound hosts' do
+    with_env('SCRAPING_MIN_INTERVAL_JOYSOUND' => '0.7') do
+      ScrapingRateLimiter.throttle('https://www.joysound.com/a') { nil }
+      ScrapingRateLimiter.throttle('https://www.joysound.com/b') { nil }
+    end
+
+    assert_equal [0.7], @sleep_calls
+  end
+
+  test 'concurrent calls to the same host are serialized and each waits the full interval' do
+    with_env('SCRAPING_MIN_INTERVAL_DAM' => '1.0') do
+      threads = Array.new(4) do
+        Thread.new { ScrapingRateLimiter.throttle('https://www.clubdam.com/concurrent') { nil } }
+      end
+      threads.each(&:join)
+    end
+
+    assert_equal [1.0, 1.0, 1.0], @sleep_calls.sort
+  end
+
+  private
+
+  def with_env(overrides)
+    original = overrides.keys.index_with { |key| ENV.fetch(key, nil) }
+    overrides.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    original.each { |key, value| ENV[key] = value }
+  end
+end

--- a/test/services/song_external_sync_test.rb
+++ b/test/services/song_external_sync_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SongExternalSyncTest < ActiveSupport::TestCase
+  class HaltAfterCapture < StandardError; end
+
+  test 'fetch_joysound_songs wires a persistent JoysoundScraper worker_factory and worker_teardown into process_with_progress' do
+    captured = capture_process_with_progress_kwargs(Song) { SongExternalSync.fetch_joysound_songs }
+
+    assert_respond_to captured[:worker_factory], :call
+    assert_respond_to captured[:worker_teardown], :call
+
+    worker = captured[:worker_factory].call
+    assert_instance_of Scrapers::JoysoundScraper, worker
+  end
+
+  test 'fetch_joysound_music_post_song wires a persistent JoysoundScraper worker_factory and worker_teardown into process_with_progress' do
+    captured = capture_process_with_progress_kwargs(Song) { SongExternalSync.fetch_joysound_music_post_song }
+
+    assert_respond_to captured[:worker_factory], :call
+    assert_respond_to captured[:worker_teardown], :call
+
+    worker = captured[:worker_factory].call
+    assert_instance_of Scrapers::JoysoundScraper, worker
+  end
+
+  test 'fetch_dam_songs wires a persistent DamScraper worker_factory and worker_teardown into process_with_progress' do
+    captured = capture_process_with_progress_kwargs(Song) { SongExternalSync.fetch_dam_songs }
+
+    assert_respond_to captured[:worker_factory], :call
+    assert_respond_to captured[:worker_teardown], :call
+
+    worker = captured[:worker_factory].call
+    assert_instance_of Scrapers::DamScraper, worker
+  end
+
+  test 'update_dam_delivery_models wires a persistent DamScraper worker_factory and worker_teardown into process_with_progress' do
+    captured = capture_process_with_progress_kwargs(Song) { SongExternalSync.update_dam_delivery_models }
+
+    assert_respond_to captured[:worker_factory], :call
+    assert_respond_to captured[:worker_teardown], :call
+
+    worker = captured[:worker_factory].call
+    assert_instance_of Scrapers::DamScraper, worker
+  end
+
+  private
+
+  # Song.process_with_progressをスタブし、渡されたkwargsを捕捉した直後に例外で処理を打ち切る。
+  # ブロック本体やスクレイピング（実サイトへのアクセス）は一切実行されない。
+  def capture_process_with_progress_kwargs(klass, &)
+    captured = nil
+    original = klass.method(:process_with_progress)
+
+    klass.define_singleton_method(:process_with_progress) do |*_args, **kwargs, &_block|
+      captured = kwargs
+      raise HaltAfterCapture
+    end
+
+    assert_raises(HaltAfterCapture, &)
+    captured
+  ensure
+    klass.define_singleton_method(:process_with_progress) do |*args, **kwargs|
+      original.call(*args, **kwargs, &)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

スクレイピングを**実並列化**し、相手サイト（DAM/JOYSOUND）に負荷をかけない範囲で安全・堅牢に高速化しました。PR #689 で整備した並列基盤（`SCRAPING_THREAD_COUNT` opt-in）の上に、スレッド毎ブラウザ割り当て・ブラウザ再利用・ホスト別レート制御・堅牢なエラー処理を実装し、既定で3並列を有効化しています。

## 実装内容

| ステップ | 内容 |
|---|---|
| リトライ堅牢化 | 指数バックオフ+jitter、`Ferrum::DeadBrowserError` をリトライ対象に追加 |
| BrowserManager 永続モード | ブラウザ再利用（毎回のChrome起動/終了を回避）、`reset_session`、disk-cache抑制、`visit` の有限タイムアウト |
| ワーカープール | スレッド毎に専用ブラウザを持つワーカーを生成・再利用・確実に後始末。`find_in_batches` でメモリ境界化。`executor.wrap` + `connection_pool.with_connection` でAR接続をスレッド安全化。スレッド数をコネクションプールサイズにクランプ |
| BaseScraper ライフサイクル | N件毎にChromeプロセス再生成（メモリ/キャッシュ肥大対策）、DAMのリトライ範囲を統一 |
| 呼び出し側配線 | `SongExternalSync`・`JoysoundMusicPostManager` をスレッド毎ワーカー方式へ |
| ホスト別レートリミッタ | 実効QPSをスレッド数に依存させず、ホスト単位に最小リクエスト間隔を強制（既定1req/秒） |
| エラー耐性 | 並列中の1レコード失敗は握り潰して継続（失敗を集約報告）、連続失敗が閾値到達で安全に早期終了 |
| 既定並列有効化 | `SCRAPING_THREAD_COUNT` 既定を3に |

## 堅牢性への配慮

- **メモリリーク防止**: 全件一括ロードを避けバッチ処理、N件毎にChrome再生成、`ensure` で全ブラウザ確実にquit
- **キャッシュ肥大対策**: 各レコード後に `reset_session`(cookie/cache/traffic クリア)＋disk-cache抑制＋プロセス再生成
- **内部ネットワーク不調**: 指数バックオフ再試行＋有限タイムアウト（無限ハング防止）＋連続失敗での早期終了

## 環境変数（運用チューニング）

| 変数 | 既定 | 説明 |
|---|---|---|
| `SCRAPING_THREAD_COUNT` | 3 | 並列スレッド数（コネクションプールサイズでクランプ） |
| `SCRAPING_MIN_INTERVAL_DAM` / `_JOYSOUND` / `_DEFAULT` | 1.0 | ホスト別の最小リクエスト間隔（秒） |
| `SCRAPING_BROWSER_MAX_USES` | 50 | ブラウザ再生成までの処理件数 |
| `SCRAPING_CONSECUTIVE_FAILURE_LIMIT` | 10 | 連続失敗での早期終了閾値 |

## 検証

### 単体テスト
- 全 **424 テスト緑**（新規: retryable / browser_manager / parallel_processor拡張 / scraping_rate_limiter / base_scraper / 呼び出し側配線）、RuboCop クリーン
- テスト環境は決定性のため `SCRAPING_THREAD_COUNT=1` を既定化（並列パス検証テストは自前でスレッド数を制御）

### 実環境検証（別DBを作成し実DAMサイトを実測、既存DBは無変更）

| 項目 | 逐次(1) | 並列(3) |
|---|---|---|
| 8件の所要時間 | 15.79秒 | **9.88秒（約1.6倍高速）** |
| 実ワーカースレッド数 | 1 | 3（真の並列） |
| データ正常性 | 8/8 | 8/8 |
| リクエスト開始間隔 | 約1.9秒 | **約1.0秒（3並列でもホスト1req/秒を維持）** |

- 実行前後でChromeプロセス数が不変（ゾンビ残留なし）
- 不正URL混在でもバッチ完走（正常分を保存）
