### PR TITLE
カラオケ楽曲の原曲紐づけ: プレビュー入力保持バグ修正と個別ページからの原曲追加機能

### DIFF
--- a/app/controllers/admin/karaoke_song_bulk_edits_controller.rb
+++ b/app/controllers/admin/karaoke_song_bulk_edits_controller.rb
@@ -8,7 +8,8 @@ module Admin
     }.freeze
 
     helper_method :karaoke_song_bulk_edit_columns, :karaoke_song_bulk_edit_column_labels, :karaoke_song_bulk_edit_column_label,
-                  :karaoke_song_bulk_edit_status_options, :karaoke_song_bulk_edit_per_page_options
+                  :karaoke_song_bulk_edit_status_options, :karaoke_song_bulk_edit_per_page_options,
+                  :karaoke_song_bulk_edit_submitted_field, :karaoke_song_bulk_edit_original_song_field
 
     def index
       authorize Song
@@ -35,10 +36,11 @@ module Admin
       authorize Song, preview_request? ? :index? : :update?
 
       if preview_request?
+        @submitted_rows = bulk_tsv.present? ? {} : song_rows
         @preview_result = if bulk_tsv.present?
                             KaraokeSongBulkEditor.new(actor_name: current_user.name).preview_from_tsv(bulk_tsv)
                           else
-                            KaraokeSongBulkEditor.new(actor_name: current_user.name).preview_from_form_rows(song_rows)
+                            KaraokeSongBulkEditor.new(actor_name: current_user.name).preview_from_form_rows(@submitted_rows)
                           end
         load_index
         flash.now[:alert] = @preview_result.errors.join("\n") if @preview_result.errors.present?
@@ -138,6 +140,16 @@ module Admin
 
     def karaoke_song_bulk_edit_per_page_options
       PER_PAGE_OPTIONS
+    end
+
+    def karaoke_song_bulk_edit_submitted_field(song, column)
+      row = @submitted_rows && @submitted_rows[song.id.to_s]
+      row&.key?(column) ? row[column].to_s : song.public_send(column).to_s
+    end
+
+    def karaoke_song_bulk_edit_original_song_field(song)
+      row = @submitted_rows && @submitted_rows[song.id.to_s]
+      row&.key?('original_songs') ? row['original_songs'].to_s : song.original_songs.map(&:title).join('/')
     end
 
     def requested_per_page

--- a/app/controllers/admin/karaoke_song_delivery_url_bulk_edits_controller.rb
+++ b/app/controllers/admin/karaoke_song_delivery_url_bulk_edits_controller.rb
@@ -7,7 +7,8 @@ module Admin
                   :karaoke_song_delivery_url_sort_options,
                   :karaoke_song_delivery_url_sort_direction_options,
                   :karaoke_song_delivery_url_per_page_options,
-                  :karaoke_song_delivery_url_karaoke_type_options
+                  :karaoke_song_delivery_url_karaoke_type_options,
+                  :karaoke_song_delivery_url_submitted_field
 
     def index
       authorize Song
@@ -18,10 +19,11 @@ module Admin
       authorize Song, preview_request? ? :index? : :update?
 
       if preview_request?
+        @submitted_rows = bulk_tsv.present? ? {} : song_rows
         @preview_result = if bulk_tsv.present?
                             editor.preview_from_tsv(bulk_tsv)
                           else
-                            editor.preview_from_form_rows(song_rows)
+                            editor.preview_from_form_rows(@submitted_rows)
                           end
         load_index
         flash.now[:alert] = @preview_result.errors.join("\n") if @preview_result.errors.present?
@@ -106,6 +108,11 @@ module Admin
 
     def karaoke_song_delivery_url_karaoke_type_options
       @karaoke_song_delivery_url_karaoke_type_options ||= Song.distinct.order(:karaoke_type).pluck(:karaoke_type).compact_blank
+    end
+
+    def karaoke_song_delivery_url_submitted_field(song, column)
+      row = @submitted_rows && @submitted_rows[song.id.to_s]
+      row&.key?(column) ? row[column].to_s : song.public_send(column).to_s
     end
 
     def song_rows

--- a/app/controllers/admin/songs_controller.rb
+++ b/app/controllers/admin/songs_controller.rb
@@ -1,5 +1,30 @@
 module Admin
   class SongsController < ResourcesController
     self.resource_key = :song
+
+    # NOTE: intentionally a distinct callback name (not `:set_record`). Redeclaring
+    # `before_action :set_record, only: ...` here would replace ResourcesController's
+    # existing `set_record` callback (Rails callback chains key on the method symbol),
+    # silently dropping `show`/`edit`/`update`/etc. from its `only:` list.
+    before_action :set_record_for_original_songs, only: :original_songs
+
+    def original_songs
+      authorize @record, :update?
+
+      result = KaraokeSongBulkEditor.new(actor_name: current_user.name).update_original_songs_for(@record, params[:original_songs])
+
+      if result.errors.present?
+        redirect_to admin_resource_path(@resource, @record), alert: result.errors.join("\n")
+      else
+        notice = result.updated_count.positive? ? '原曲紐づけを更新しました。' : '変更はありませんでした。'
+        redirect_to admin_resource_path(@resource, @record), notice:
+      end
+    end
+
+    private
+
+    def set_record_for_original_songs
+      set_record
+    end
   end
 end

--- a/app/javascript/admin/original_song_picker.js
+++ b/app/javascript/admin/original_song_picker.js
@@ -133,7 +133,7 @@ const resolveOriginalSongText = async (picker, text) => {
   return response.json()
 }
 
-export const setOriginalSongPickerText = async (searchInput, text) => {
+export const setOriginalSongPickerText = async (searchInput, text, { append = false } = {}) => {
   const picker = searchInput.closest("[data-admin-original-song-picker]")
   if (!picker) {
     searchInput.value = text
@@ -145,7 +145,8 @@ export const setOriginalSongPickerText = async (searchInput, text) => {
     const items = payload.items?.length
       ? payload.items.map((item) => ({ title: item.title, status: item.exists ? "valid" : "invalid" }))
       : [{ title: text, status: payload.titles?.length ? "valid" : "invalid" }]
-    updateOriginalSongPickerValue(picker, items)
+    const nextItems = append ? [...selectedOriginalSongItems(picker), ...items] : items
+    updateOriginalSongPickerValue(picker, nextItems)
     const selectedTitles = new Set(selectedOriginalSongTitles(picker))
     const candidates = (payload.items || []).flatMap((item) => (
       item.exists ? [] : (item.candidates || []).map((candidate) => ({
@@ -163,7 +164,8 @@ export const setOriginalSongPickerText = async (searchInput, text) => {
     }
   } catch (error) {
     console.error(error)
-    updateOriginalSongPickerValue(picker, [{ title: text, status: "invalid" }])
+    const invalidItem = { title: text, status: "invalid" }
+    updateOriginalSongPickerValue(picker, append ? [...selectedOriginalSongItems(picker), invalidItem] : [invalidItem])
     hideOriginalSongOptions(picker)
   } finally {
     searchInput.value = ""
@@ -271,7 +273,7 @@ export const setupAdminOriginalSongPickers = () => {
       }
 
       const text = event.target.value.trim()
-      if (text) setOriginalSongPickerText(event.target, text)
+      if (text) setOriginalSongPickerText(event.target, text, { append: true })
     })
 
     picker.querySelector("[data-admin-original-song-search]")?.addEventListener("paste", (event) => {
@@ -279,7 +281,7 @@ export const setupAdminOriginalSongPickers = () => {
       if (!text || text.includes("\t") || text.includes("\n")) return
 
       event.preventDefault()
-      setOriginalSongPickerText(event.target, text)
+      setOriginalSongPickerText(event.target, text, { append: true })
     })
   })
 }

--- a/app/models/admin/change_log.rb
+++ b/app/models/admin/change_log.rb
@@ -28,11 +28,20 @@ module Admin
         record_event!(resource:, record:, actor_name:, event: 'create', changes: record.previous_changes)
       end
 
-      def record_update!(resource:, record:, actor_name:)
-        changes = visible_changes(resource, record.previous_changes)
-        return if changes.blank?
+      def record_update!(resource:, record:, actor_name:, extra_changed_fields: {})
+        changed_fields = visible_changes(resource, record.previous_changes).merge(extra_changed_fields)
+        return if changed_fields.blank?
 
-        record_event!(resource:, record:, actor_name:, event: 'update', changes: record.previous_changes)
+        create!(
+          resource_key: resource.key.to_s,
+          resource_label: resource.label,
+          record_type: record.class.name,
+          record_id: record_identifier(record),
+          record_title: record_title(resource, record),
+          event: 'update',
+          changed_fields:,
+          actor_name:
+        )
       end
 
       def record_destroy!(resource:, record:, actor_name:)

--- a/app/models/admin/karaoke_song_bulk_editor.rb
+++ b/app/models/admin/karaoke_song_bulk_editor.rb
@@ -98,16 +98,7 @@ module Admin
       song.original_songs = original_songs
       return Result.new(updated_count: 0, skipped_count: 1, errors: []) if before_codes == song.original_songs.map(&:code).sort
 
-      # `original_songs` is a has_many :through association, so reassigning it never touches Song's
-      # own columns and ChangeLog.record_update! would otherwise see a blank `previous_changes` and
-      # skip logging. Pass the before/after titles explicitly so the link change is still recorded.
-      original_songs_change = {
-        'original_songs' => {
-          label: '原曲',
-          before: before_titles.join('/').presence,
-          after: song.original_songs.map(&:title).join('/').presence
-        }
-      }
+      original_songs_change = original_songs_change_log_field(changed: true, before_titles:, after_titles: song.original_songs.map(&:title))
 
       Song.transaction do
         song.save!
@@ -227,15 +218,35 @@ module Admin
 
     def update_applied?(update)
       song = update.fetch(:song)
-      before_original_song_codes = song.original_songs.map(&:code).sort
+      before_codes = song.original_songs.map(&:code).sort
+      before_titles = song.original_songs.map(&:title)
       song.original_songs = update.fetch(:original_songs)
       song.assign_attributes(update.fetch(:attributes))
-      original_songs_changed = before_original_song_codes != song.original_songs.map(&:code).sort
+      original_songs_changed = before_codes != song.original_songs.map(&:code).sort
       return false unless original_songs_changed || song.changed?
 
+      original_songs_change = original_songs_change_log_field(
+        changed: original_songs_changed, before_titles:, after_titles: song.original_songs.map(&:title)
+      )
+
       song.save!
-      ChangeLog.record_update!(resource: song_resource, record: song, actor_name:)
+      ChangeLog.record_update!(resource: song_resource, record: song, actor_name:, extra_changed_fields: original_songs_change)
       true
+    end
+
+    # `original_songs` is a has_many :through association, so reassigning it never touches Song's
+    # own columns and ChangeLog.record_update! would otherwise see a blank `previous_changes` and
+    # skip logging. Build the before/after titles explicitly so the link change is still recorded.
+    def original_songs_change_log_field(changed:, before_titles:, after_titles:)
+      return {} unless changed
+
+      {
+        'original_songs' => {
+          label: '原曲',
+          before: before_titles.join('/').presence,
+          after: after_titles.join('/').presence
+        }
+      }
     end
 
     def normalized_url_attributes(row)

--- a/app/models/admin/karaoke_song_bulk_editor.rb
+++ b/app/models/admin/karaoke_song_bulk_editor.rb
@@ -88,6 +88,34 @@ module Admin
       }
     end
 
+    def update_original_songs_for(song, text)
+      errors = []
+      original_songs = resolve_original_songs(text.to_s, 1, errors)
+      return Result.new(updated_count: 0, skipped_count: 0, errors: errors.map { |error| error.sub(/\A1行目: /, '') }) if errors.present?
+
+      before_codes = song.original_songs.map(&:code).sort
+      before_titles = song.original_songs.map(&:title)
+      song.original_songs = original_songs
+      return Result.new(updated_count: 0, skipped_count: 1, errors: []) if before_codes == song.original_songs.map(&:code).sort
+
+      # `original_songs` is a has_many :through association, so reassigning it never touches Song's
+      # own columns and ChangeLog.record_update! would otherwise see a blank `previous_changes` and
+      # skip logging. Pass the before/after titles explicitly so the link change is still recorded.
+      original_songs_change = {
+        'original_songs' => {
+          label: '原曲',
+          before: before_titles.join('/').presence,
+          after: song.original_songs.map(&:title).join('/').presence
+        }
+      }
+
+      Song.transaction do
+        song.save!
+        ChangeLog.record_update!(resource: song_resource, record: song, actor_name:, extra_changed_fields: original_songs_change)
+      end
+      Result.new(updated_count: 1, skipped_count: 0, errors: [])
+    end
+
     private
 
     attr_reader :actor_name, :song_resource

--- a/app/views/admin/karaoke_song_bulk_edits/index.html.erb
+++ b/app/views/admin/karaoke_song_bulk_edits/index.html.erb
@@ -155,7 +155,7 @@
                   data-options-url="<%= admin_karaoke_song_bulk_edit_original_song_options_path %>"
                   data-resolve-url="<%= admin_karaoke_song_bulk_edit_resolve_original_songs_path %>">
                   <%= hidden_field_tag "songs[#{song.id}][original_songs]",
-                                       song.original_songs.map(&:title).join('/'),
+                                       karaoke_song_bulk_edit_original_song_field(song),
                                        data: { admin_original_song_value: true } %>
                   <div class="admin-original-song-chips" data-admin-original-song-chips></div>
                   <div class="admin-original-song-search-wrap">
@@ -173,7 +173,7 @@
               <% Admin::KaraokeSongBulkEditor::URL_COLUMNS.each_with_index do |column, column_index| %>
                 <td>
                   <%= url_field_tag "songs[#{song.id}][#{column}]",
-                                    song.public_send(column),
+                                    karaoke_song_bulk_edit_submitted_field(song, column),
                                     class: "admin-bulk-cell input input-bordered",
                                     placeholder: karaoke_song_url_placeholder(column),
                                     aria: { label: "#{song.title}の#{karaoke_song_bulk_edit_column_label(column)}" },

--- a/app/views/admin/karaoke_song_delivery_url_bulk_edits/index.html.erb
+++ b/app/views/admin/karaoke_song_delivery_url_bulk_edits/index.html.erb
@@ -193,7 +193,7 @@
               <% Admin::KaraokeSongDeliveryUrlBulkEditor::URL_COLUMNS.each_with_index do |column, column_index| %>
                 <td>
                   <%= url_field_tag "songs[#{song.id}][#{column}]",
-                                    song.public_send(column),
+                                    karaoke_song_delivery_url_submitted_field(song, column),
                                     class: "admin-bulk-cell input input-bordered",
                                     placeholder: karaoke_song_url_placeholder(column),
                                     aria: { label: "#{song.title}の#{karaoke_song_delivery_url_column_label(column)}" },

--- a/app/views/admin/resources/show.html.erb
+++ b/app/views/admin/resources/show.html.erb
@@ -106,6 +106,12 @@
                 <span>紐づけ</span>
               </button>
             <% end %>
+            <% if @resource.key == :song && association == :original_songs && policy(@record).update? %>
+              <button type="button" class="admin-button btn btn-sm" aria-label="<%= admin_record_title(@resource, @record) %>の原曲を紐づけ" data-admin-association-dialog-trigger="song-original-songs">
+                <%= admin_icon(:edit) %>
+                <span>紐づけ</span>
+              </button>
+            <% end %>
           </header>
           <% if records.present? %>
             <ul class="admin-related-list">
@@ -164,4 +170,54 @@
       </form>
     </dialog>
   <% end %>
+<% end %>
+
+<% if @resource.key == :song && policy(@record).update? %>
+  <dialog class="modal admin-association-dialog" aria-labelledby="admin-association-dialog-title-song-original-songs" data-admin-association-dialog="song-original-songs">
+    <div class="modal-box admin-association-dialog-box">
+      <div class="admin-operation-modal-header">
+        <div>
+          <span class="admin-operation-modal-resource">関連データ</span>
+          <h2 id="admin-association-dialog-title-song-original-songs">原曲を紐づけ</h2>
+        </div>
+        <button type="button" class="btn btn-sm btn-circle btn-ghost" aria-label="閉じる" data-admin-association-dialog-close><%= admin_icon(:clear) %></button>
+      </div>
+
+      <%= form_with url: original_songs_admin_song_path(@record), method: :patch, class: "admin-form admin-association-dialog-form" do %>
+        <div
+          class="admin-original-song-picker"
+          data-admin-original-song-picker
+          data-options-url="<%= admin_karaoke_song_bulk_edit_original_song_options_path %>"
+          data-resolve-url="<%= admin_karaoke_song_bulk_edit_resolve_original_songs_path %>">
+          <%= hidden_field_tag :original_songs,
+                               @record.original_songs.map(&:title).join('/'),
+                               data: { admin_original_song_value: true } %>
+          <div class="admin-original-song-chips" data-admin-original-song-chips></div>
+          <div class="admin-original-song-search-wrap">
+            <%= text_field_tag nil,
+                               nil,
+                               class: "admin-bulk-cell admin-original-song-search input input-bordered",
+                               autocomplete: "off",
+                               placeholder: "原曲を検索",
+                               aria: { label: "#{admin_record_title(@resource, @record)}の原曲を検索" },
+                               data: { admin_original_song_search: true } %>
+            <div class="admin-original-song-options" data-admin-original-song-options hidden></div>
+          </div>
+        </div>
+        <div class="admin-form-actions">
+          <%= button_tag type: :submit, class: "admin-button admin-button-primary btn btn-primary", aria: { label: "原曲紐づけを更新" } do %>
+            <%= admin_icon(:edit) %>
+            <span>更新</span>
+          <% end %>
+          <button type="button" class="admin-button btn" aria-label="原曲紐づけをキャンセル" data-admin-association-dialog-close>
+            <%= admin_icon(:clear) %>
+            <span>キャンセル</span>
+          </button>
+        </div>
+      <% end %>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button type="submit">閉じる</button>
+    </form>
+  </dialog>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       get :operation, on: :collection
       post :operation, on: :collection
       get :operation_progress, on: :collection
+      patch :original_songs, on: :member
     end
     resources :display_artists do
       get :operation, on: :collection

--- a/test/controllers/admin/karaoke_song_bulk_edits_controller_test.rb
+++ b/test/controllers/admin/karaoke_song_bulk_edits_controller_test.rb
@@ -199,6 +199,47 @@ module Admin
       assert_equal '', song.youtube_url
     end
 
+    test 'preview retains submitted original song and youtube url values in rendered fields' do
+      song = create_song(title: 'Controller Preview Retains Song')
+      first_original_song = create_original_song(title: 'Controller Preview Retains First')
+      second_original_song = create_original_song(title: 'Controller Preview Retains Second')
+
+      post admin_karaoke_song_bulk_edit_path, params: {
+        mode: 'preview',
+        songs: {
+          song.id => {
+            original_songs: "#{first_original_song.title}/#{second_original_song.title}",
+            youtube_url: 'https://youtube.example/preview-retained'
+          }
+        }
+      }
+
+      assert_response :success
+      assert_select 'input[name=?][value=?]', "songs[#{song.id}][original_songs]", "#{first_original_song.title}/#{second_original_song.title}"
+      assert_select 'input[name=?][value=?]', "songs[#{song.id}][youtube_url]", 'https://youtube.example/preview-retained'
+    end
+
+    test 'preview shows submitted original song value instead of previously linked db value' do
+      song = create_song(title: 'Controller Preview Already Linked Song', youtube_url: 'https://youtube.example/existing-before-clear')
+      song.original_songs << create_original_song(title: 'Controller Preview Existing Original')
+      replacement_original_song = create_original_song(title: 'Controller Preview Replacement Original')
+
+      post admin_karaoke_song_bulk_edit_path, params: {
+        mode: 'preview',
+        status: 'all',
+        songs: {
+          song.id => {
+            original_songs: replacement_original_song.title,
+            youtube_url: ''
+          }
+        }
+      }
+
+      assert_response :success
+      assert_select 'input[name=?][value=?]', "songs[#{song.id}][original_songs]", replacement_original_song.title
+      assert_select 'input[name=?][value=?]', "songs[#{song.id}][youtube_url]", ''
+    end
+
     test 'updates from pasted export tsv' do
       song = create_song(title: 'Controller TSV Song')
       original_song = create_original_song(title: 'Controller TSV Original')

--- a/test/controllers/admin/karaoke_song_delivery_url_bulk_edits_controller_test.rb
+++ b/test/controllers/admin/karaoke_song_delivery_url_bulk_edits_controller_test.rb
@@ -182,6 +182,28 @@ module Admin
       assert_equal '', song.reload.youtube_url
     end
 
+    test 'preview shows submitted youtube url instead of existing db value' do
+      song = create_song(title: 'Controller Delivery URL Preview Submitted Song', youtube_url: 'https://youtube.example/existing-db-value')
+
+      post admin_karaoke_song_delivery_url_bulk_edit_path, params: {
+        mode: 'preview',
+        songs: {
+          song.id => {
+            youtube_url: 'https://youtube.example/preview-submitted',
+            nicovideo_url: '',
+            apple_music_url: '',
+            youtube_music_url: '',
+            spotify_url: '',
+            line_music_url: ''
+          }
+        }
+      }
+
+      assert_response :success
+      assert_select 'input[name=?][value=?]', "songs[#{song.id}][youtube_url]", 'https://youtube.example/preview-submitted'
+      assert_equal 'https://youtube.example/existing-db-value', song.reload.youtube_url
+    end
+
     test 'updates from pasted delivery url tsv' do
       song = create_song(title: 'Controller Delivery URL TSV Song')
       tsv = [

--- a/test/controllers/admin/songs_controller_test.rb
+++ b/test/controllers/admin/songs_controller_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+module Admin
+  class SongsControllerTest < ActionDispatch::IntegrationTest
+    test 'show page renders the original song picker with the current chips' do
+      original_song = create_original_song(title: 'Show Page Original')
+      song = create_song
+      song.original_songs = [original_song]
+
+      get admin_song_path(song)
+
+      assert_response :success
+      assert_select '[data-admin-association-dialog-trigger="song-original-songs"]', text: /紐づけ/
+      assert_select 'dialog[data-admin-association-dialog="song-original-songs"]' do
+        assert_select '[data-admin-original-song-picker]'
+        assert_select 'input[type="hidden"][name="original_songs"][value=?][data-admin-original-song-value]', original_song.title
+        assert_select 'form[action=?][method="post"]', original_songs_admin_song_path(song) do
+          assert_select 'input[name="_method"][value="patch"]', 1
+        end
+      end
+    end
+
+    test 'original_songs action links a resolved original song and redirects to show' do
+      song = create_song(youtube_url: 'https://youtube.example/keep')
+      original_song = create_original_song(title: 'Controller Link Original')
+
+      assert_difference -> { Admin::ChangeLog.count }, 1 do
+        patch original_songs_admin_song_path(song), params: { original_songs: original_song.title }
+      end
+
+      assert_redirected_to admin_song_path(song)
+      follow_redirect!
+      assert_select '.admin-flash-notice', text: '原曲紐づけを更新しました。'
+      song.reload
+      assert_equal [original_song], song.original_songs.to_a
+      assert_equal 'https://youtube.example/keep', song.youtube_url
+    end
+
+    test 'original_songs action replaces existing links with the submitted chip set' do
+      existing_original_song = create_original_song(title: 'Existing Controller Original')
+      additional_original_song = create_original_song(title: 'Additional Controller Original')
+      song = create_song
+      song.original_songs = [existing_original_song]
+
+      patch original_songs_admin_song_path(song), params: {
+        original_songs: "#{existing_original_song.title}/#{additional_original_song.title}"
+      }
+
+      assert_redirected_to admin_song_path(song)
+      assert_equal [existing_original_song.code, additional_original_song.code].sort, song.reload.original_songs.map(&:code).sort
+    end
+
+    test 'original_songs action redirects with an alert when a title cannot be resolved' do
+      song = create_song
+
+      patch original_songs_admin_song_path(song), params: { original_songs: 'Missing Controller Original' }
+
+      assert_redirected_to admin_song_path(song)
+      follow_redirect!
+      assert_select '.admin-flash-alert', text: /Missing Controller Original/
+      assert_empty song.reload.original_songs
+    end
+  end
+end

--- a/test/javascript/admin/original_song_picker_test.mjs
+++ b/test/javascript/admin/original_song_picker_test.mjs
@@ -192,6 +192,30 @@ test("setOriginalSongPickerText resolves selected items and renders candidates f
   assert.equal(fixture.options.children[0].dataset.adminOriginalSongCandidateFor, "紅楼?")
 })
 
+test("setOriginalSongPickerText appends to existing selection when append is true", async () => {
+  const fixture = buildPicker({ initialValue: "既存曲" })
+  globalThis.document.querySelectorAll = (selector) => (
+    selector === "[data-admin-original-song-picker]" ? [fixture.picker] : []
+  )
+  setupAdminOriginalSongPickers()
+
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      items: [
+        { exists: true, title: "新しい曲" },
+      ],
+    }),
+  })
+
+  await setOriginalSongPickerText(fixture.search, "新しい曲", { append: true })
+
+  assert.equal(fixture.search.value, "")
+  assert.equal(fixture.valueInput.value, "既存曲/新しい曲")
+  assert.deepEqual(fixture.chips.children.map((chip) => chip.textContent), ["既存曲", "新しい曲"])
+  assert.deepEqual(fixture.chips.children.map((chip) => chip.dataset.adminOriginalSongStatus), ["valid", "valid"])
+})
+
 test("setOriginalSongPickerText marks text invalid when resolve fails", async () => {
   const fixture = buildPicker()
   const errors = []

--- a/test/models/admin/karaoke_song_bulk_editor_test.rb
+++ b/test/models/admin/karaoke_song_bulk_editor_test.rb
@@ -24,6 +24,24 @@ module Admin
       assert_equal 'https://youtube.example/watch', song.youtube_url
     end
 
+    test 'records a change log from a bulk edit that only changes the linked original song' do
+      song = create_song
+      original_song = create_original_song(title: 'Bulk Original Only Change')
+
+      assert_difference -> { Admin::ChangeLog.count }, 1 do
+        result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_from_form_rows(
+          song.id => { 'original_songs' => original_song.title }
+        )
+
+        assert_empty result.errors
+        assert_equal 1, result.updated_count
+        assert_equal 0, result.skipped_count
+      end
+
+      assert_equal [original_song], song.reload.original_songs.to_a
+      assert_equal 'update', Admin::ChangeLog.last.event
+    end
+
     test 'updates rows from exported tsv columns' do
       song = create_song(title: 'TSV Bulk Song')
       original_song = create_original_song(title: 'TSV Bulk Original')

--- a/test/models/admin/karaoke_song_bulk_editor_test.rb
+++ b/test/models/admin/karaoke_song_bulk_editor_test.rb
@@ -296,5 +296,85 @@ module Admin
       assert_empty song.reload.original_songs
       assert_equal '', song.youtube_url
     end
+
+    test 'update_original_songs_for links a song to a resolved original song and records a change log' do
+      song = create_song(youtube_url: 'https://youtube.example/keep')
+      original_song = create_original_song(title: 'Individual Link Original')
+
+      assert_difference -> { Admin::ChangeLog.count }, 1 do
+        result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_original_songs_for(song, original_song.title)
+
+        assert_empty result.errors
+        assert_equal 1, result.updated_count
+        assert_equal 0, result.skipped_count
+      end
+
+      assert_equal [original_song], song.reload.original_songs.to_a
+      assert_equal 'https://youtube.example/keep', song.youtube_url
+      assert_equal 'update', Admin::ChangeLog.last.event
+    end
+
+    test 'update_original_songs_for skips saving when the requested original songs are unchanged' do
+      original_song = create_original_song(title: 'Unchanged Individual Original')
+      song = create_song
+      song.original_songs = [original_song]
+
+      assert_no_difference -> { Admin::ChangeLog.count } do
+        result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_original_songs_for(song, original_song.title)
+
+        assert_empty result.errors
+        assert_equal 0, result.updated_count
+        assert_equal 1, result.skipped_count
+      end
+
+      assert_equal [original_song], song.reload.original_songs.to_a
+    end
+
+    test 'update_original_songs_for returns errors and does not change links for an unknown title' do
+      original_song = create_original_song(title: 'Known Individual Original')
+      song = create_song
+      song.original_songs = [original_song]
+
+      assert_no_difference -> { Admin::ChangeLog.count } do
+        result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_original_songs_for(song, 'Missing Individual Original')
+
+        assert_equal 1, result.errors.size
+        assert_match(/Missing Individual Original/, result.errors.first)
+        assert_equal 0, result.updated_count
+        assert_equal 0, result.skipped_count
+      end
+
+      assert_equal [original_song], song.reload.original_songs.to_a
+    end
+
+    test 'update_original_songs_for adds an additional original song alongside an existing one' do
+      existing_original_song = create_original_song(title: 'Existing Individual Original')
+      additional_original_song = create_original_song(title: 'Additional Individual Original')
+      song = create_song
+      song.original_songs = [existing_original_song]
+
+      result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_original_songs_for(
+        song, "#{existing_original_song.title}/#{additional_original_song.title}"
+      )
+
+      assert_empty result.errors
+      assert_equal 1, result.updated_count
+      assert_equal [existing_original_song.code, additional_original_song.code].sort, song.reload.original_songs.map(&:code).sort
+    end
+
+    test 'update_original_songs_for does not touch delivery url columns' do
+      song = create_song(
+        youtube_url: 'https://youtube.example/untouched',
+        nicovideo_url: 'https://nicovideo.example/untouched'
+      )
+      original_song = create_original_song(title: 'URL Preserving Individual Original')
+
+      result = KaraokeSongBulkEditor.new(actor_name: '管理者').update_original_songs_for(song, original_song.title)
+
+      assert_empty result.errors
+      song.reload
+      assert_equal 'https://youtube.example/untouched', song.youtube_url
+      assert_equal 'https://nicovideo.example/untouched', song.nicovideo_url
+    end
   end
 end


### PR DESCRIPTION
## 概要

カラオケ楽曲の原曲紐づけまわりのバグ修正と機能追加です。

## 背景 / 課題

- 「カラオケ楽曲紐づけ」「カラオケ配信URL編集」画面で、原曲チップやURLを入力して「紐づけチェック / 変更チェック」を押すと、**上部にチェック結果は出るのに下部テーブルの入力欄が「未設定」に戻り**、「チェック結果を反映」しても何も更新されない。URLを入れても反映ボタンが反応しない、という症状も同根。
- 複数原曲の紐づけを「1度に全部」だけでなく、**後から1曲ずつ追加**したいという要望。

## 変更内容

### 1. `fix`: プレビューで入力欄が消えるバグを修正（両画面）
preview(`mode=preview`) 時に `@preview_result` 算出後の `load_index` が `@songs` をDBから再取得し、ビューが入力欄をDB値で再描画していたことが原因。プレビュー時に送信値 `@submitted_rows` を保持し、入力欄を送信値優先で再描画するよう修正。`Hash#key?` で「未送信」と「空文字送信(クリア意図)」を区別。

### 2. `feat`: 楽曲個別ページから原曲を追加できる機能を新設
楽曲詳細ページ (`/admin/songs/:id`) の関連「原曲」に「紐づけ」ボタンを追加し、既存の原曲ピッカーを流用したモーダルで検索・1曲ずつ追加・削除・複数まとめ入力ができるように。「1度に全部」も「後から1曲ずつ」も両方可能。

- `KaraokeSongBulkEditor#update_original_songs_for` 追加（URL列に触れず原曲のみ更新）
- `patch :original_songs` member ルート / `Admin::SongsController#original_songs` 追加
- `resources/show.html.erb` に Song 用の紐づけダイアログ分岐を追加
- `original_songs` は `has_many :through` で再代入しても Song 自身がダーティにならず ChangeLog が記録されないため、`ChangeLog.record_update!` に `extra_changed_fields:`（後方互換）を追加して原曲変更を記録

### 3. `fix`: 一括編集での原曲紐づけ変更がChangeLogに記録されない問題を修正
上記と同じ `has_many :through` の記録漏れが `update_applied?` にも存在。`extra_changed_fields` で原曲の前後差分を記録するよう修正し、差分ハッシュ組み立ては共通の private ヘルパーに集約(DRY)。

## テスト

- `devbox run test`: **437 runs, 3100 assertions, 0 failures**
- `devbox run rubocop`: **281 files, no offenses**
- 追加テスト: プレビュー時の入力保持（両画面）、`update_original_songs_for`、`SongsController#original_songs`、一括編集の原曲変更ChangeLog記録

## 動作確認手順

1. `/admin/karaoke_song_bulk_edit` で原曲チップ追加＋YouTube URL入力 →「紐づけチェック」→ 入力が消えないこと → 「反映」でDB反映
2. `status=linked` で既存紐づけ曲に原曲を1曲追加 → チェック → 既存＋追加の両方が保持されること
3. `/admin/karaoke_song_delivery_url_bulk_edit` でURL入力 →「変更チェック」→ 入力が消えないこと
4. `/admin/songs/:id` の関連「原曲」→「紐づけ」→ モーダルで検索・追加・削除 →「更新」→ 原曲一覧と変更履歴が更新、他のURLが消えないこと